### PR TITLE
Implement changes for line items pull request

### DIFF
--- a/PlanToIntroduceLineItems.md
+++ b/PlanToIntroduceLineItems.md
@@ -1,0 +1,1072 @@
+# Plan To Introduce Line Items Into Place Order Flow
+
+## Executive Summary
+
+This document outlines the approach to add line items (name, quantity, unitPrice, reference) to the Place Order API while maintaining backward compatibility and a single, unversioned domain model. The solution uses versioned request DTOs at the API boundary, with an assembler layer translating between API versions and the unified domain model.
+
+---
+
+## 1. Current State Analysis
+
+### 1.1 Current API Structure
+- **Controller**: `PlaceOrderController` uses `@PostMapping(headers = "version=1.0.0")`
+- **Request DTO**: `PlaceOrderRequest` (record) with:
+  - `Currency currency`
+  - `Long amount` (in minor units, e.g., cents)
+- **Command**: `PlaceOrderCommand` mirrors the request structure
+- **Domain**: `Order` (record) and `OrderAggregate` (JPA entity) both store:
+  - `UUID id`
+  - `long version` (JPA optimistic locking, not API versioning)
+  - `OrderStatus status`
+  - `Currency currency`
+  - `Long amount`
+
+### 1.2 Current Versioning Mechanism
+- Spring's `headers = "version=1.0.0"` annotation-based routing
+- **Problem**: If no version header is sent, the endpoint doesn't match (404)
+- **Requirement**: Default to latest version when header is absent
+
+### 1.3 Key Constraints
+- ✅ Single `Order` domain object (no versioning)
+- ✅ Single `OrderAggregate` (no versioning - the `version` field is for JPA optimistic locking)
+- ✅ Multiple versions of `PlaceOrderRequest` DTOs allowed
+- ✅ Default to latest version when no header is sent
+
+---
+
+## 2. Design Philosophy
+
+### 2.1 Core Principles
+
+1. **Domain Stability**: The domain model (`Order`, `OrderAggregate`) remains version-agnostic. All versioning happens at the API boundary (controllers and DTOs).
+
+2. **Backward Compatibility**: Existing clients using `version=1.0.0` continue to work without changes.
+
+3. **Version Isolation**: Each API version has its own DTO, but they all map to the same domain model through an assembler layer.
+
+4. **Default to Latest**: When no version header is provided, the system defaults to the latest version (V2).
+
+5. **Additive Changes**: New versions add fields; never remove fields in-place to maintain compatibility.
+
+### 2.2 Architecture Layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    HTTP Request Layer                        │
+│  (with or without version header)                            │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Controller Layer (Versioned)                    │
+│  PlaceOrderController: method overloading with @PostMapping │
+│  - @PostMapping(headers = "version=1.0.0") → V1 handler     │
+│  - @PostMapping → V2 handler (default, no header required)  │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│              DTO Layer (Versioned)                           │
+│  PlaceOrderRequestV1 | PlaceOrderRequestV2                  │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Mapper Layer (Version Agnostic)                  │
+│  PlaceOrderCommandMapper: V1/V2 DTO → PlaceOrderCommand      │
+│  (Creates synthetic line item for V1)                        │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Service Layer (Version Agnostic)                │
+│  PlaceOrderService: Command → OrderAggregate                 │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Domain Layer (Single Version)                   │
+│  OrderAggregate (with List<LineItem>)                       │
+│  Order (domain record)                                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Detailed Design
+
+### 3.1 Domain Model Changes
+
+#### 3.1.0 Update OrderPlacedEvent
+
+```java
+// Update OrderPlacedEvent.java to include line items
+@Value
+@ToString
+@Externalized("orders-events.v1.topic::#{getId().toString()}")
+@AllArgsConstructor(onConstructor_ = @JsonCreator)
+public class OrderPlacedEvent {
+
+    UUID id;
+    Long version;
+    Order.OrderStatus status;
+    Currency currency;
+    Long amount;
+    List<LineItem> lineItems;  // NEW
+
+}
+```
+
+**Rationale**:
+- Include line items in the event for complete order information
+- Allows event consumers to access line item details
+- Maintains backward compatibility (existing consumers can ignore new field)
+
+#### 3.1.1 Introduce LineItem Value Object
+
+```java
+// com.ead.payments.orders.LineItem.java
+public record LineItem(
+    String name,
+    int quantity,
+    Long unitPrice,  // in minor units (e.g., cents)
+    String reference  // nullable
+) {
+    public LineItem {
+        Preconditions.checkArgument(name != null && !name.isBlank(), 
+            "Line item name is required");
+        Preconditions.checkArgument(quantity > 0, 
+            "Line item quantity must be greater than 0");
+        Preconditions.checkArgument(unitPrice != null && unitPrice >= 0, 
+            "Line item unit price must be non-negative");
+    }
+    
+    public Long lineTotal() {
+        return unitPrice * quantity;
+    }
+}
+```
+
+**Rationale**: 
+- Using `Long` for prices (minor units) to match existing `amount` field pattern
+- `reference` is nullable to support optional use cases
+- No validation here - validation happens in `OrderAggregate` constructor
+
+#### 3.1.2 Update OrderAggregate
+
+```java
+// Add to OrderAggregate.java
+@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+private List<OrderLineItemEntity> lineItems = new ArrayList<>();
+
+// Update constructor to accept List<LineItem>
+public OrderAggregate(PlaceOrderCommand command) {
+    // Existing validations
+    Preconditions.checkNotNull(command.currency(), "The currency is required");
+    Preconditions.checkNotNull(command.lineItems(), "Line items are required");
+    // Note: Line items can be empty for V1 orders
+    
+    // Validate each line item
+    for (LineItem item : command.lineItems()) {
+        Preconditions.checkArgument(item.quantity() > 0, 
+            "Line item quantity must be greater than 0");
+        Preconditions.checkArgument(item.unitPrice() != null && item.unitPrice() >= 0, 
+            "Line item unit price must be non-negative");
+    }
+    
+    // Validate all line items have same currency (if currency per line item is added later)
+    // For now, currency is at command level
+    
+    // Convert LineItems to entities
+    this.lineItems = command.lineItems().stream()
+        .map(item -> new OrderLineItemEntity(this, item))
+        .toList();
+    
+    // Compute total from line items (if any)
+    Long computedTotal = lineItems.stream()
+        .mapToLong(OrderLineItemEntity::getLineTotal)
+        .sum();
+    
+    // Validate that computed total matches the provided amount (if provided)
+    if (command.amount() != null) {
+        Preconditions.checkArgument(
+            computedTotal.equals(command.amount()),
+            "Line items total (%s) does not match provided amount (%s)",
+            computedTotal,
+            command.amount()
+        );
+    }
+    
+    // For V1 orders (empty line items), use the provided amount
+    // For V2 orders, use computed total from line items
+    this.amount = command.amount() != null ? command.amount() : computedTotal;
+    Preconditions.checkArgument(this.amount > 0, "The amount must be greater than 0");
+    
+    this.id = command.id();
+    this.status = OrderStatus.PLACED;
+    this.currency = command.currency();
+    
+        registerEvent(new OrderPlacedEvent(
+        command.id(),
+        version,
+        status,
+        command.currency(),
+        this.amount,
+        command.lineItems()  // Include line items in event
+    ));
+}
+```
+
+**Rationale**:
+- Keep `amount` field for query efficiency (denormalized)
+- Compute `amount` from line items to ensure consistency
+- Use JPA entity for line items to handle persistence
+
+#### 3.1.3 Update Order Domain Record
+
+```java
+// Update Order.java
+public record Order(
+    UUID id,
+    long version,
+    OrderStatus status,
+    Currency currency,
+    Long amount,
+    List<LineItem> lineItems  // NEW
+) {
+    // ... existing code ...
+}
+```
+
+**Rationale**: 
+- Add `lineItems` to domain record for complete domain representation
+- Keep backward compatibility by making it a new field
+
+#### 3.1.4 Update SearchOrderResponse
+
+```java
+// Update SearchOrderResponse.java to include line items
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchOrderResponse {
+
+    private @NotNull UUID id;
+    private @NotNull @Min(0L) Long version;
+    private @NotNull Currency currency;
+    private @NotNull Long amount;
+    private @NotNull List<LineItemResponse> lineItems;  // NEW
+}
+
+// New DTO for line items in response
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LineItemResponse {
+    private @NotBlank String name;
+    private @Min(1) int quantity;
+    private @NotNull @Min(0L) Long unitPrice;
+    private String reference;  // nullable
+}
+```
+
+**Rationale**:
+- Include line items in search response for complete order information
+- Separate response DTO (`LineItemResponse`) for API contract clarity
+- Allows clients to see line item details when retrieving orders
+
+### 3.2 Request DTO Versioning
+
+#### 3.2.1 PlaceOrderRequestV1 (Rename Current)
+
+```java
+// com.ead.payments.orders.place.dto.PlaceOrderRequestV1.java
+public record PlaceOrderRequestV1(
+    @NotNull Currency currency,
+    @NotNull @Min(0L) Long amount
+) {
+    // This is the current PlaceOrderRequest renamed
+}
+```
+
+**Rationale**: 
+- Rename existing `PlaceOrderRequest` to `PlaceOrderRequestV1` for clarity
+- Maintain exact same structure for backward compatibility
+
+#### 3.2.2 PlaceOrderRequestV2 (New)
+
+```java
+// com.ead.payments.orders.place.dto.PlaceOrderRequestV2.java
+public record PlaceOrderRequestV2(
+    @NotNull Currency currency,
+    @NotNull @Size(min = 1, max = 100) @Valid List<LineItemRequest> lineItems,
+    @Min(0L) Long amount  // Optional: for validation if provided
+) {
+}
+
+// com.ead.payments.orders.place.dto.LineItemRequest.java
+public record LineItemRequest(
+    @NotBlank String name,
+    @Min(1) int quantity,
+    @NotNull @Min(0L) Long unitPrice,
+    String reference  // nullable, no validation needed
+) {
+}
+```
+
+**Rationale**:
+- `amount` is optional in V2 (can be computed from line items)
+- If `amount` is provided, it must match sum of line items (validation in service layer)
+- Max 100 line items to prevent abuse
+- `reference` is nullable to match domain model
+- Bean validation annotations for DTO-level validation (Spring handles this)
+
+### 3.3 Command Layer Update
+
+```java
+// Update PlaceOrderCommand.java
+public record PlaceOrderCommand(
+    UUID id,
+    Currency currency,
+    Long amount,  // Keep for backward compatibility during transition
+    List<LineItem> lineItems  // NEW
+) {
+}
+```
+
+**Rationale**:
+- Add `lineItems` to command
+- Keep `amount` during transition (can be removed later if not needed)
+- Command remains version-agnostic
+
+### 3.4 Mapper Layer (Using MapStruct)
+
+#### 3.4.1 Dedicated LineItemMapper
+
+```java
+// com.ead.payments.orders.place.mapping.LineItemMapper.java
+@Mapper(componentModel = "spring")
+public interface LineItemMapper {
+    
+    /**
+     * Maps LineItemRequest DTO to domain LineItem.
+     * MapStruct automatically generates implementation for this mapping.
+     */
+    @Mapping(target = "name", source = "name")
+    @Mapping(target = "quantity", source = "quantity")
+    @Mapping(target = "unitPrice", source = "unitPrice")
+    @Mapping(target = "reference", source = "reference")
+    LineItem toLineItem(LineItemRequest dto);
+    
+    /**
+     * Maps list of LineItemRequest DTOs to list of domain LineItems.
+     * MapStruct automatically handles list mapping by calling toLineItem for each element.
+     */
+    List<LineItem> toLineItems(List<LineItemRequest> dtos);
+}
+```
+
+**Rationale**:
+- **Dedicated mapper**: Separates line item mapping concerns into its own mapper
+- **Reusable**: Can be injected into other mappers that need line item conversion
+- **MapStruct generated**: Automatic, type-safe, compile-time code generation
+
+#### 3.4.2 PlaceOrderCommandMapper
+
+```java
+// com.ead.payments.orders.place.mapping.PlaceOrderCommandMapper.java
+@Mapper(componentModel = "spring", uses = {LineItemMapper.class})
+public interface PlaceOrderCommandMapper {
+    
+    /**
+     * Maps V1 request to command. Uses empty list for line items.
+     * No validation - validation happens in OrderAggregate constructor.
+     */
+    default PlaceOrderCommand toCommand(PlaceOrderRequestV1 request, UUID orderId) {
+        return new PlaceOrderCommand(
+            orderId,
+            request.currency(),
+            request.amount(),
+            List.of()  // Empty list for V1
+        );
+    }
+    
+    /**
+     * Maps V2 request to command. Uses LineItemMapper (injected via uses) for line item conversion.
+     * No validation - validation happens in service layer and OrderAggregate constructor.
+     */
+    default PlaceOrderCommand toCommand(PlaceOrderRequestV2 request, UUID orderId, LineItemMapper lineItemMapper) {
+        // Use injected LineItemMapper to convert DTO line items to domain LineItems
+        List<LineItem> lineItems = lineItemMapper.toLineItems(request.lineItems());
+        
+        // Compute total from line items
+        Long computedTotal = lineItems.stream()
+            .mapToLong(LineItem::lineTotal)
+            .sum();
+        
+        return new PlaceOrderCommand(
+            orderId,
+            request.currency(),
+            computedTotal,
+            lineItems
+        );
+    }
+}
+```
+
+**Alternative: Using MapStruct's automatic injection (recommended)**
+
+```java
+// com.ead.payments.orders.place.mapping.PlaceOrderCommandMapper.java
+@Mapper(componentModel = "spring", uses = {LineItemMapper.class})
+public interface PlaceOrderCommandMapper {
+    
+    /**
+     * Maps V1 request to command. Uses empty list for line items.
+     * No validation - validation happens in OrderAggregate constructor.
+     */
+    default PlaceOrderCommand toCommand(PlaceOrderRequestV1 request, UUID orderId) {
+        return new PlaceOrderCommand(
+            orderId,
+            request.currency(),
+            request.amount(),
+            List.of()  // Empty list for V1
+        );
+    }
+    
+    /**
+     * Maps V2 request to command.
+     * MapStruct automatically injects LineItemMapper (via uses annotation) into generated implementation.
+     * The generated code will call lineItemMapper.toLineItems() for the lineItems field.
+     */
+    @Mapping(target = "id", ignore = true)  // id is provided separately
+    @Mapping(target = "amount", expression = "java(computeTotalFromLineItems(request.lineItems()))")
+    @Mapping(target = "lineItems", source = "lineItems", qualifiedByName = "toLineItems")
+    PlaceOrderCommand toCommand(PlaceOrderRequestV2 request, UUID orderId);
+    
+    /**
+     * Helper method to compute total from line items.
+     * Used in @Mapping expression.
+     */
+    default Long computeTotalFromLineItems(List<LineItemRequest> lineItems) {
+        return lineItems.stream()
+            .mapToLong(item -> item.unitPrice() * item.quantity())
+            .sum();
+    }
+}
+```
+
+**Note**: Since MapStruct's `uses` annotation injects the mapper at the implementation level, and we're using default methods for V1, we have two options:
+1. Use default methods for both V1 and V2, manually injecting LineItemMapper as a parameter (shown in first example)
+2. Use MapStruct's automatic mapping for V2 with `@Mapping` annotations, which will automatically use the injected LineItemMapper (shown in second example)
+
+**Recommended approach**: Use default methods for both versions and manually inject LineItemMapper:
+
+```java
+// com.ead.payments.orders.place.mapping.PlaceOrderCommandMapper.java
+@Mapper(componentModel = "spring", uses = {LineItemMapper.class})
+public interface PlaceOrderCommandMapper {
+    
+    /**
+     * Maps V1 request to command. Uses empty list for line items.
+     */
+    default PlaceOrderCommand toCommand(PlaceOrderRequestV1 request, UUID orderId) {
+        return new PlaceOrderCommand(
+            orderId,
+            request.currency(),
+            request.amount(),
+            List.of()  // Empty list for V1
+        );
+    }
+    
+    /**
+     * Maps V2 request to command. Uses injected LineItemMapper for line item conversion.
+     * MapStruct will inject LineItemMapper into the generated implementation,
+     * and we can access it via a default method that receives it as parameter,
+     * or we can use @AfterMapping to access it.
+     * 
+     * However, since we're using default methods, the cleanest approach is to
+     * manually inject LineItemMapper in the controller and pass it here.
+     * 
+     * Alternatively, we can use MapStruct's @Context annotation pattern.
+     */
+    default PlaceOrderCommand toCommand(PlaceOrderRequestV2 request, UUID orderId, LineItemMapper lineItemMapper) {
+        // Use injected LineItemMapper to convert DTO line items to domain LineItems
+        List<LineItem> lineItems = lineItemMapper.toLineItems(request.lineItems());
+        
+        // Compute total from line items
+        Long computedTotal = lineItems.stream()
+            .mapToLong(LineItem::lineTotal)
+            .sum();
+        
+        return new PlaceOrderCommand(
+            orderId,
+            request.currency(),
+            computedTotal,
+            lineItems
+        );
+    }
+}
+```
+
+**Rationale**:
+- **Uses MapStruct**: Leverages MapStruct's annotation processing for type-safe, compile-time mapping
+- **Dedicated LineItemMapper**: Separates concerns, reusable, injectable via `uses` annotation
+- **Empty list for V1**: No synthetic line item - V1 orders have empty line items list
+- **Automatic injection**: MapStruct's `uses` annotation automatically injects LineItemMapper into generated implementation
+- **No validation in mapper** - pure transformation only
+- Method overloading (same name, different parameters) eliminates need for version suffixes
+
+### 3.5 Search Order Controller Updates
+
+```java
+// Update SearchOrderController.java
+@GetMapping(path = "/{order_id}", headers = "version=1.0.0")
+@ResponseStatus(HttpStatus.OK)
+public Optional<SearchOrderResponse> searchOrder(@PathVariable("order_id") @NotNull UUID orderId) {
+    return searchOrderService.search(orderId)
+            .map(order -> new SearchOrderResponse(
+                    order.id(),
+                    order.version(),
+                    order.currency(),
+                    order.amount(),
+                    order.lineItems().stream()
+                        .map(item -> new LineItemResponse(
+                            item.name(),
+                            item.quantity(),
+                            item.unitPrice(),
+                            item.reference()
+                        ))
+                        .toList()
+            ));
+}
+```
+
+**Rationale**:
+- Include line items in search response
+- Convert domain `LineItem` to response DTO `LineItemResponse`
+- Maintains backward compatibility (existing clients can ignore new field if needed)
+
+### 3.6 Controller Strategy
+
+**Using Spring's Built-in Header-Based Routing (No ApiVersionResolver Needed)**
+
+Spring Boot's `@PostMapping` with `headers` attribute provides built-in version routing. We use method overloading with different parameter types to handle different versions:
+
+```java
+// Update PlaceOrderController.java
+@RestController
+@RequestMapping(path = "/orders")
+@RequiredArgsConstructor
+@RolesAllowed({"ROLE_MERCHANT", "ROLE_CUSTOMER"})
+public class PlaceOrderController {
+    
+    private final PlaceOrderService placeOrderService;
+    private final PlaceOrderCommandMapper commandMapper;
+    private final LineItemMapper lineItemMapper;
+    
+    /**
+     * V1 endpoint: Explicit version header required.
+     * Method overloading allows same method name with different parameter types.
+     */
+    @PostMapping(headers = "version=1.0.0")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Observed(
+        name = "http.orders.create",
+        contextualName = "POST /orders",
+        lowCardinalityKeyValues = {"version", "1.0.0"}
+    )
+    public PlaceOrderResponse placeOrder(
+            @RequestBody @Valid @NotNull PlaceOrderRequestV1 request) {
+        
+        UUID orderId = UUID.randomUUID();
+        var command = commandMapper.toCommand(request, orderId);
+        var order = placeOrderService.handle(command);
+        
+        return new PlaceOrderResponse(
+            order.id(),
+            order.currency(),
+            order.amount()
+        );
+    }
+    
+    /**
+     * V2 endpoint: Default (no version header required).
+     * Spring will route requests without version header to this method.
+     * Method overloading with different parameter type (PlaceOrderRequestV2).
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Observed(
+        name = "http.orders.create",
+        contextualName = "POST /orders",
+        lowCardinalityKeyValues = {"version", "2.0.0"}
+    )
+    public PlaceOrderResponse placeOrder(
+            @RequestBody @Valid @NotNull PlaceOrderRequestV2 request) {
+        
+        UUID orderId = UUID.randomUUID();
+        var command = commandMapper.toCommand(request, orderId, lineItemMapper);
+        var order = placeOrderService.handle(command);
+        
+        return new PlaceOrderResponse(
+            order.id(),
+            order.currency(),
+            order.amount()
+        );
+    }
+}
+```
+
+**Rationale**:
+- **No ApiVersionResolver needed**: Spring's header matching handles routing automatically
+- **Method overloading**: Same method name `placeOrder()` with different parameter types (`PlaceOrderRequestV1` vs `PlaceOrderRequestV2`)
+- **Default behavior**: `@PostMapping` without `headers` attribute matches requests without version header → defaults to V2
+- **Explicit V1**: `@PostMapping(headers = "version=1.0.0")` matches requests with V1 header
+- **Version tags in @Observed**: Added `lowCardinalityKeyValues = {"version", "1.0.0"}` and `{"version", "2.0.0"}` for observability
+- **Clean separation**: Each version has its own method, making the code explicit and easy to understand
+
+### 3.6 Persistence Layer
+
+#### 3.6.1 Database Schema
+
+```sql
+-- Migration: V{timestamp}__add_line_items.sql
+
+-- Create line_items table
+CREATE TABLE IF NOT EXISTS orders.line_items (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    order_id UUID NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    quantity INTEGER NOT NULL CHECK (quantity > 0),
+    unit_price_minor_units BIGINT NOT NULL CHECK (unit_price_minor_units >= 0),
+    reference VARCHAR(255),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (order_id) REFERENCES orders.orders(order_id) ON DELETE CASCADE,
+    UNIQUE (order_id, name, reference)  -- Optional: prevent duplicates
+);
+
+-- Index for efficient order lookup
+CREATE INDEX IF NOT EXISTS idx_line_items_order_id ON orders.line_items(order_id);
+
+-- Note: orders.amount remains for query efficiency (denormalized)
+-- Consistency ensured via application logic
+```
+
+#### 3.6.2 JPA Entity
+
+```java
+// com.ead.payments.orders.OrderLineItemEntity.java
+@Entity
+@Table(name = "line_items", schema = "orders")
+@Data
+@NoArgsConstructor
+public class OrderLineItemEntity {
+    
+    @Id
+    @GeneratedValue
+    private UUID id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private OrderAggregate order;
+    
+    @Column(nullable = false)
+    private String name;
+    
+    @Column(nullable = false)
+    private Integer quantity;
+    
+    @Column(name = "unit_price_minor_units", nullable = false)
+    private Long unitPrice;
+    
+    @Column
+    private String reference;
+    
+    public OrderLineItemEntity(OrderAggregate order, LineItem lineItem) {
+        this.order = order;
+        this.name = lineItem.name();
+        this.quantity = lineItem.quantity();
+        this.unitPrice = lineItem.unitPrice();
+        this.reference = lineItem.reference();
+    }
+    
+    public Long getLineTotal() {
+        return unitPrice * quantity;
+    }
+}
+```
+
+**Rationale**:
+- Separate entity for persistence concerns
+- Cascade delete ensures line items are removed with order
+- Optional unique constraint prevents duplicate line items per order
+
+### 3.7 Service Layer Updates
+
+```java
+// Update PlaceOrderService.java
+@Service
+@RequiredArgsConstructor
+public class PlaceOrderService {
+    
+    final OrderAggregateMapper orderAggregateMapper;
+    final OrderRepository orderRepository;
+    final IssuerService issuerService;
+    
+    public Order handle(PlaceOrderCommand command) {
+        // Cross-entity validation (if needed)
+        // Example: Validate order against issuer service limits, customer limits, etc.
+        // This is validation that spans multiple entities/aggregates
+        
+        // Note: If V2 request provided an amount, validation that it matches computed total
+        // would happen here (spans request DTO and command). However, since we compute
+        // the total in the mapper and the command already has the computed total, this
+        // validation is not needed unless we want to validate against a provided amount
+        // that was passed separately. For now, we trust the mapper's computation.
+        
+        // Authorization (unchanged)
+        Authorization authorization = issuerService.authorize(command);
+        if (authorization instanceof RejectedAuthorization(String status, String statusReason)) {
+            throw new IssuerDeclinedException(
+                "Authorization was rejected with status: " + status + 
+                " and state reason: " + statusReason
+            );
+        }
+        
+        // Additional cross-entity validations can go here
+        // Example: Check if customer has exceeded order limit
+        // Example: Check if total amount exceeds merchant limits
+        
+        // Create aggregate (validations for single entity happen in OrderAggregate constructor)
+        OrderAggregate aggregate = new OrderAggregate(command);
+        
+        // Save (line items cascade)
+        aggregate = orderRepository.save(aggregate);
+        
+        return orderAggregateMapper.toOrder(aggregate);
+    }
+}
+```
+
+**Rationale**: 
+- Service layer remains version-agnostic
+- Works with `PlaceOrderCommand` that now includes line items
+- **Cross-entity validations**: Only validations that span multiple entities/aggregates go here
+- **Single-entity validations**: All validations for OrderAggregate and its properties go in `OrderAggregate` constructor
+- No version-specific logic in service
+
+### 3.8 Mapper Updates
+
+```java
+// Update OrderAggregateMapper.java
+@Mapper(componentModel = "spring")
+public interface OrderAggregateMapper {
+    
+    /**
+     * Maps OrderAggregate to Order domain record.
+     * MapStruct automatically handles simple field mappings.
+     */
+    @Mapping(target = "lineItems", source = "lineItems")
+    Order toOrder(OrderAggregate orderAggregate);
+    
+    /**
+     * Maps OrderLineItemEntity to LineItem value object.
+     * MapStruct automatically generates this mapping.
+     */
+    @Mapping(target = "name", source = "name")
+    @Mapping(target = "quantity", source = "quantity")
+    @Mapping(target = "unitPrice", source = "unitPrice")
+    @Mapping(target = "reference", source = "reference")
+    LineItem toLineItem(OrderLineItemEntity entity);
+    
+    /**
+     * Maps list of OrderLineItemEntity to list of LineItem.
+     * MapStruct automatically handles list mapping.
+     */
+    List<LineItem> toLineItems(List<OrderLineItemEntity> entities);
+}
+```
+
+**Rationale**: 
+- **Uses MapStruct**: Leverages MapStruct's automatic mapping generation
+- **Type-safe**: Compile-time checking ensures correct mappings
+- **Efficient**: Generated code has no reflection overhead
+- MapStruct automatically handles the list conversion by calling `toLineItem` for each element
+
+---
+
+## 4. Implementation Steps
+
+### Phase 1: Domain Model (No Breaking Changes)
+1. ✅ Create `LineItem` value object
+2. ✅ Create `OrderLineItemEntity` JPA entity
+3. ✅ Add database migration for `line_items` table
+4. ✅ Update `OrderAggregate` to include line items (backward compatible)
+5. ✅ Update `Order` domain record to include line items
+6. ✅ Update `PlaceOrderCommand` to include line items
+
+### Phase 2: API Versioning Infrastructure
+7. ✅ Rename `PlaceOrderRequest` → `PlaceOrderRequestV1`
+8. ✅ Create `PlaceOrderRequestV2` and `LineItemRequest`
+9. ✅ Create `LineItemMapper` using MapStruct
+10. ✅ Create `PlaceOrderCommandMapper` using MapStruct with `uses = {LineItemMapper.class}`
+11. ✅ Update `OrderPlacedEvent` to include line items
+12. ✅ Update `SearchOrderResponse` to include line items
+
+### Phase 3: Controller Updates
+13. ✅ Update `PlaceOrderController` with method overloading (V1 and V2 endpoints)
+14. ✅ Add version tags to `@Observed` annotations
+15. ✅ Update `OrderAggregateMapper` to map line items using MapStruct
+16. ✅ Update `SearchOrderController` to include line items in response
+17. ✅ Add validations to `OrderAggregate` constructor (including line items total match)
+18. ✅ Add cross-entity validations to `PlaceOrderService` (if needed)
+
+### Phase 4: Testing
+15. ✅ Unit tests for `PlaceOrderCommandMapper` (V1 and V2 paths, MapStruct mappings)
+16. ✅ Unit tests for `OrderAggregate` constructor validations (including line items total match validation)
+17. ✅ Integration tests for V1 endpoint (backward compatibility)
+18. ✅ Integration tests for V2 endpoint (with line items)
+19. ✅ Integration tests for default version (no header → V2)
+20. ✅ **Integration test: Place order with line items → verify OrderPlacedEvent contains line items → GET order → verify line items in response**
+
+### Phase 5: Documentation
+19. ✅ Update OpenAPI/Swagger documentation
+20. ✅ Add migration guide for API clients
+21. ✅ Document versioning strategy
+
+---
+
+## 5. Backward Compatibility Strategy
+
+### 5.1 V1 Clients
+- **No changes required**: Existing clients using `version=1.0.0` header continue to work
+- **Behavior**: V1 requests create orders with empty line items list (lineItems = [])
+
+### 5.2 New Clients
+- **Default behavior**: No version header → V2 (latest)
+- **Explicit versioning**: Can still use `version=1.0.0` or `version=2.0.0`
+
+### 5.3 Migration Path
+1. Deploy V2 support (V1 still works)
+2. Monitor usage: track V1 vs V2 adoption
+3. Communicate deprecation timeline (e.g., V1 deprecated in 6 months)
+4. Eventually remove V1 endpoint (assembler logic can remain for data migration)
+
+---
+
+## 6. Validation Rules
+
+### 6.1 V1 Validation
+- `currency`: required, not null
+- `amount`: required, >= 0
+
+### 6.2 V2 Validation
+- **DTO-level (Bean Validation)**: Handled by Spring's `@Valid` annotation
+  - `currency`: required, not null
+  - `lineItems`: required, size 1-100, each item validated
+  - `amount`: optional
+  - Line item validation:
+    - `name`: required, not blank
+    - `quantity`: required, >= 1
+    - `unitPrice`: required, >= 0
+    - `reference`: optional
+
+### 6.3 Domain Validation (OrderAggregate Constructor)
+- **Single-entity validations** (happen in `OrderAggregate` constructor):
+  - Currency: required, not null
+  - Line items: can be empty (for V1 orders) or not empty (for V2 orders)
+  - Each line item (if present): quantity > 0, unitPrice >= 0
+  - **Line items total must match provided amount** (if amount is provided in command and line items are not empty)
+  - Total amount: must be > 0 (from provided amount for V1, or computed from line items for V2)
+
+### 6.4 Service Layer Validation (Cross-Entity)
+- **Cross-entity validations** (happen in `PlaceOrderService.handle()`):
+  - If amount provided in V2 request, validate it matches computed total (spans request DTO and command)
+  - Authorization checks (spans Order and IssuerService)
+  - Customer order limits (spans Order and Customer entities)
+  - Merchant limits (spans Order and Merchant entities)
+
+---
+
+## 7. Error Handling
+
+### 7.1 Error Codes
+- `LINE_ITEMS_EMPTY`: V2 request has empty line items list
+- `LINE_ITEM_INVALID_QUANTITY`: quantity <= 0
+- `LINE_ITEM_INVALID_UNIT_PRICE`: unitPrice < 0
+- `LINE_ITEMS_TOTAL_MISMATCH`: provided amount doesn't match computed total
+- `LINE_ITEMS_TOO_MANY`: more than 100 line items
+- `MULTI_CURRENCY_NOT_SUPPORTED`: line items have different currencies
+
+### 7.2 Error Response Format
+Maintain existing error response format (likely ProblemDetail based on `OrderControlAdvice`).
+
+---
+
+## 8. Testing Strategy
+
+### 8.1 Unit Tests
+- `PlaceOrderCommandMapperTest`: 
+  - Test V1 → empty line items list mapping
+  - Test V2 → real line items mapping using LineItemMapper
+  - No validation tests - mapper is pure transformation
+- `LineItemMapperTest`:
+  - Test MapStruct-generated `toLineItem` and `toLineItems` methods
+  - Test mapping from LineItemRequest to LineItem
+  - Test list mapping
+- `OrderAggregateTest`: 
+  - Test line item aggregation, total computation
+  - Test constructor validations (including line items total must match provided amount)
+  - Test validation failure when line items total doesn't match amount
+- `PlaceOrderServiceTest`: Test cross-entity validations (if any)
+- `OrderAggregateMapperTest`: Test MapStruct mapping from OrderAggregate to Order (including line items)
+
+### 8.2 Integration Tests
+- `PlaceOrderControllerTest`: Test V1 endpoint, V2 endpoint, default version resolution
+- Test backward compatibility: existing V1 clients still work
+- Test new V2 clients with multiple line items
+- **Test: Place order with line items → verify event → GET order → verify response**
+  - Place order via POST with line items (V2)
+  - Verify `OrderPlacedEvent` is published with correct line items
+  - Retrieve order via GET endpoint
+  - Verify `SearchOrderResponse` contains the same line items
+
+#### 8.2.1 Example Integration Test: Line Items End-to-End
+
+```java
+// PlaceOrderWithLineItemsIntegrationTest.java
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("PlaceOrderWithLineItemsIntegrationTest")
+class PlaceOrderWithLineItemsIntegrationTest {
+    
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @Autowired
+    private OrderRepository orderRepository;
+    
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+    
+    @Test
+    @DisplayName("Should place order with line items and retrieve them via GET When order is created with V2 request")
+    void shouldPlaceOrderWithLineItemsAndRetrieveThemViaGetWhenV2Request() throws Exception {
+        // Given: V2 request with line items
+        PlaceOrderRequestV2 request = new PlaceOrderRequestV2(
+            Currency.getInstance("USD"),
+            List.of(
+                new LineItemRequest("Product A", 2, 1000L, "REF-001"),
+                new LineItemRequest("Product B", 1, 2000L, "REF-002")
+            ),
+            null  // amount not provided, should be computed
+        );
+        
+        // When: Place order
+        var placeOrderResult = mockMvc.perform(post("/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andReturn();
+        
+        PlaceOrderResponse placeResponse = objectMapper.readValue(
+            placeOrderResult.getResponse().getContentAsString(),
+            PlaceOrderResponse.class
+        );
+        UUID orderId = placeResponse.id();
+        
+        // Then: Verify OrderPlacedEvent contains line items
+        // (This would typically use Spring Modulith's Scenario or EventListener verification)
+        // For example, using @ApplicationModuleTest:
+        // scenario.publish(new OrderPlacedEvent(...))
+        //   .andWaitForEventOfType(OrderPlacedEvent.class)
+        //   .matching(event -> event.getLineItems().size() == 2)
+        //   .toArrive();
+        
+        // When: Retrieve order via GET
+        var getOrderResult = mockMvc.perform(get("/orders/{order_id}", orderId)
+                .header("version", "1.0.0"))
+            .andExpect(status().isOk())
+            .andReturn();
+        
+        SearchOrderResponse searchResponse = objectMapper.readValue(
+            getOrderResult.getResponse().getContentAsString(),
+            SearchOrderResponse.class
+        );
+        
+        // Then: Verify response contains line items
+        assertThat(searchResponse.getLineItems()).hasSize(2);
+        assertThat(searchResponse.getLineItems().get(0).getName()).isEqualTo("Product A");
+        assertThat(searchResponse.getLineItems().get(0).getQuantity()).isEqualTo(2);
+        assertThat(searchResponse.getLineItems().get(0).getUnitPrice()).isEqualTo(1000L);
+        assertThat(searchResponse.getLineItems().get(0).getReference()).isEqualTo("REF-001");
+        assertThat(searchResponse.getLineItems().get(1).getName()).isEqualTo("Product B");
+        assertThat(searchResponse.getLineItems().get(1).getQuantity()).isEqualTo(1);
+        assertThat(searchResponse.getLineItems().get(1).getUnitPrice()).isEqualTo(2000L);
+        assertThat(searchResponse.getLineItems().get(1).getReference()).isEqualTo("REF-002");
+        
+        // Verify total matches sum of line items
+        Long expectedTotal = (2 * 1000L) + (1 * 2000L); // 4000L
+        assertThat(searchResponse.getAmount()).isEqualTo(expectedTotal);
+    }
+}
+```
+
+**Rationale**:
+- Tests the complete flow: POST → Event → GET
+- Verifies line items are persisted and retrieved correctly
+- Validates that line items in event match line items in response
+- Ensures total amount matches sum of line items
+
+### 8.3 Migration Tests
+- Test database migration: schema created correctly
+- Test data persistence: line items saved and retrieved correctly
+
+---
+
+## 9. Risks and Mitigations
+
+### 9.1 Risk: Version Header Parsing Issues
+**Mitigation**: Using Spring's built-in header matching eliminates custom parsing logic. Default endpoint (no header) routes to V2.
+
+### 9.2 Risk: Total Mismatch Between Amount and Line Items
+**Mitigation**: Validation in service layer (if amount provided in V2 request), domain invariants in OrderAggregate constructor
+
+### 9.3 Risk: Performance with Many Line Items
+**Mitigation**: Max 100 line items limit, indexed queries
+
+### 9.4 Risk: Backward Compatibility Breaks
+**Mitigation**: Maintain V1 endpoint, thorough integration testing
+
+---
+
+## 10. Future Considerations
+
+### 10.1 Potential Enhancements
+- Remove `amount` field from V2 request (compute only)
+- Add line item-level discounts
+- Support line item metadata
+- Add idempotency key support
+
+### 10.2 Deprecation Timeline
+- **Month 0-3**: V1 and V2 both supported
+- **Month 3-6**: Communicate V1 deprecation
+- **Month 6+**: Remove V1 endpoint (keep assembler for data migration)
+
+---
+
+## 11. Summary
+
+This plan introduces line items support while maintaining:
+- ✅ Single, unversioned domain model
+- ✅ Backward compatibility for existing clients
+- ✅ Default to latest version when no header is sent (via Spring's header matching)
+- ✅ Clean separation of concerns (versioning at API boundary)
+- ✅ Validation in the right place: single-entity in aggregate, cross-entity in service
+- ✅ No custom version resolver needed (uses Spring's built-in capabilities)
+
+The key insights:
+1. **Versioning is an API concern, not a domain concern**: By using a mapper layer, we translate versioned DTOs into a unified domain model.
+2. **Spring's header matching is sufficient**: No need for custom ApiVersionResolver - method overloading with different parameter types handles version routing elegantly.
+3. **Validation placement matters**: Single-entity validations belong in the aggregate constructor; cross-entity validations belong in the service layer.

--- a/docs/OBJECT_TREE.md
+++ b/docs/OBJECT_TREE.md
@@ -1,0 +1,357 @@
+# Object Tree - Orders with Line Items
+
+## Overview
+This document shows the complete object hierarchy and relationships in the orders system with line items support.
+
+---
+
+## API Layer (Request DTOs)
+
+```
+com.ead.payments.orders.place.request/
+├── PlaceOrderRequestV1 (record)
+│   ├── Currency currency
+│   └── Long amount
+│
+├── PlaceOrderRequestV2 (record)
+│   ├── Currency currency
+│   ├── List<LineItemRequest> lineItems
+│   └── Long amount (optional)
+│
+└── LineItemRequest (record)
+    ├── String name
+    ├── int quantity
+    ├── Long unitPrice
+    └── String reference (nullable)
+```
+
+---
+
+## API Layer (Response DTOs)
+
+```
+com.ead.payments.orders.place.response/
+├── PlaceOrderResponseV1 (class)
+│   ├── UUID id
+│   ├── Currency currency
+│   └── Long amount
+│
+└── PlaceOrderResponseV2 (class)
+    ├── UUID id
+    ├── Currency currency
+    ├── Long amount
+    └── List<LineItemResponse> lineItems
+        └── (uses com.ead.payments.orders.response.LineItemResponse)
+
+com.ead.payments.orders.search/
+└── SearchOrderResponse (class)
+    ├── UUID id
+    ├── Long version
+    ├── Currency currency
+    ├── Long amount
+    └── List<LineItemResponse> lineItems
+        └── (uses com.ead.payments.orders.response.LineItemResponse)
+
+com.ead.payments.orders.response/
+└── LineItemResponse (record) ⭐ SINGLE SOURCE OF TRUTH
+    ├── String name
+    ├── int quantity
+    ├── Long unitPrice
+    └── String reference (nullable)
+```
+
+---
+
+## Mapping Layer (MapStruct Mappers)
+
+```
+com.ead.payments.orders.place.mapping/
+├── LineItemMapper
+│   ├── LineItem toLineItem(LineItemRequest) 
+│   └── List<LineItem> toLineItems(List<LineItemRequest>)
+│
+├── PlaceOrderCommandMapper (uses LineItemMapper)
+│   ├── PlaceOrderCommand toCommand(PlaceOrderRequestV1, UUID)
+│   │   └── maps to PlaceOrderCommand with empty lineItems
+│   └── PlaceOrderCommand toCommand(PlaceOrderRequestV2, UUID)
+│       └── maps to PlaceOrderCommand with computed amount from lineItems
+│
+└── PlaceOrderResponseMapper (uses LineItemResponseMapper)
+    ├── PlaceOrderResponseV1 toResponseV1(Order)
+    └── PlaceOrderResponseV2 toResponseV2(Order)
+        └── uses LineItemResponseMapper.from() for lineItems
+
+com.ead.payments.orders.search.mapping/
+└── SearchOrderResponseMapper (uses LineItemResponseMapper)
+    └── SearchOrderResponse from(Order)
+        └── uses LineItemResponseMapper.from() for lineItems
+
+com.ead.payments.orders.mapping/
+└── LineItemResponseMapper ⭐ SINGLE MAPPER FOR LineItemResponse
+    ├── LineItemResponse from(LineItem)
+    └── List<LineItemResponse> from(List<LineItem>)
+
+com.ead.payments.orders/
+└── OrderAggregateMapper
+    ├── Order toOrder(OrderAggregate)
+    ├── LineItem toLineItem(OrderLineItemEntity)
+    └── List<LineItem> toLineItems(List<OrderLineItemEntity>)
+```
+
+---
+
+## Command Layer
+
+```
+com.ead.payments.orders.place/
+└── PlaceOrderCommand (record)
+    ├── UUID id
+    ├── Currency currency
+    ├── Long amount (for backward compatibility)
+    └── List<LineItem> lineItems
+```
+
+---
+
+## Domain Layer (Value Objects & Domain Records)
+
+```
+com.ead.payments.orders/
+├── LineItem (record) ⭐ DOMAIN VALUE OBJECT
+│   ├── String name
+│   ├── int quantity
+│   ├── Long unitPrice
+│   ├── String reference (nullable)
+│   └── Long lineTotal() [computed: unitPrice * quantity]
+│
+└── Order (record) ⭐ DOMAIN RECORD
+    ├── UUID id
+    ├── long version
+    ├── OrderStatus status
+    ├── Currency currency
+    ├── Long amount
+    └── List<LineItem> lineItems
+```
+
+---
+
+## Persistence Layer (JPA Entities)
+
+```
+com.ead.payments.orders/
+├── OrderAggregate (JPA Entity) ⭐ AGGREGATE ROOT
+│   ├── @Id UUID id
+│   ├── @Version Long version
+│   ├── OrderStatus status
+│   ├── Currency currency
+│   ├── Long amount
+│   └── @OneToMany List<OrderLineItemEntity> lineItems
+│       └── (cascade = ALL, orphanRemoval = true)
+│
+└── OrderLineItemEntity (JPA Entity)
+    ├── @Id UUID id
+    ├── @ManyToOne OrderAggregate order
+    ├── String name
+    ├── Integer quantity
+    ├── Long unitPrice
+    ├── String reference
+    └── Long getLineTotal() [computed: unitPrice * quantity]
+```
+
+---
+
+## Flow Diagram
+
+### Place Order Flow (V1 - No Line Items)
+
+```
+1. HTTP POST /orders (with header: version=1.0.0)
+   └── PlaceOrderRequestV1
+       │
+       ▼
+2. PlaceOrderCommandMapper.toCommand(PlaceOrderRequestV1, UUID)
+   └── PlaceOrderCommand
+       │   ├── currency: from request
+       │   ├── amount: from request
+       │   └── lineItems: empty list []
+       │
+       ▼
+3. PlaceOrderService.handle(PlaceOrderCommand)
+   └── new OrderAggregate(command)
+       │   └── creates OrderAggregate with empty lineItems
+       │
+       ▼
+4. OrderAggregateMapper.toOrder(OrderAggregate)
+   └── Order (domain record)
+       │   └── lineItems: empty list []
+       │
+       ▼
+5. PlaceOrderResponseMapper.toResponseV1(Order)
+   └── PlaceOrderResponseV1
+       └── (no lineItems in response)
+```
+
+### Place Order Flow (V2 - With Line Items)
+
+```
+1. HTTP POST /orders (no version header = default V2)
+   └── PlaceOrderRequestV2
+       │   ├── currency
+       │   ├── lineItems: List<LineItemRequest>
+       │   └── amount: optional
+       │
+       ▼
+2. PlaceOrderCommandMapper.toCommand(PlaceOrderRequestV2, UUID)
+   │   ├── uses LineItemMapper.toLineItems() 
+   │   │   └── converts List<LineItemRequest> → List<LineItem>
+   │   │
+   │   └── computes amount from lineItems (if not provided)
+   │
+   └── PlaceOrderCommand
+       │   ├── currency: from request
+       │   ├── amount: computed from lineItems
+       │   └── lineItems: List<LineItem> (domain objects)
+       │
+       ▼
+3. PlaceOrderService.handle(PlaceOrderCommand)
+   └── new OrderAggregate(command)
+       │   ├── validates lineItems
+       │   ├── creates OrderLineItemEntity for each LineItem
+       │   ├── computes total from lineItems
+       │   └── validates amount matches computed total
+       │
+       └── OrderAggregate (JPA Entity)
+           └── lineItems: List<OrderLineItemEntity>
+           │
+           ▼
+4. OrderAggregateMapper.toOrder(OrderAggregate)
+   │   ├── uses OrderAggregateMapper.toLineItems()
+   │   │   └── converts List<OrderLineItemEntity> → List<LineItem>
+   │   │
+   └── Order (domain record)
+       └── lineItems: List<LineItem>
+       │
+       ▼
+5. PlaceOrderResponseMapper.toResponseV2(Order)
+   │   ├── uses LineItemResponseMapper.from()
+   │   │   └── converts List<LineItem> → List<LineItemResponse>
+   │   │
+   └── PlaceOrderResponseV2
+       └── lineItems: List<LineItemResponse>
+```
+
+### Search Order Flow
+
+```
+1. HTTP GET /orders/{order_id}
+   │
+   ▼
+2. SearchOrderService.search(UUID)
+   └── OrderRepository.findById(UUID)
+       └── OrderAggregate (JPA Entity)
+           │
+           ▼
+3. OrderAggregateMapper.toOrder(OrderAggregate)
+   │   ├── uses OrderAggregateMapper.toLineItems()
+   │   │   └── converts List<OrderLineItemEntity> → List<LineItem>
+   │   │
+   └── Order (domain record)
+       └── lineItems: List<LineItem>
+       │
+       ▼
+4. SearchOrderResponseMapper.from(Order)
+   │   ├── uses LineItemResponseMapper.from()
+   │   │   └── converts List<LineItem> → List<LineItemResponse>
+   │   │
+   └── SearchOrderResponse
+       └── lineItems: List<LineItemResponse>
+```
+
+---
+
+## Key Relationships
+
+### 1. LineItemResponse (Single Source of Truth)
+- **Location**: `com.ead.payments.orders.response.LineItemResponse`
+- **Used by**:
+  - `PlaceOrderResponseV2.lineItems`
+  - `SearchOrderResponse.lineItems`
+- **Mapped by**: `LineItemResponseMapper.from(LineItem)`
+
+### 2. LineItem (Domain Value Object)
+- **Location**: `com.ead.payments.orders.LineItem`
+- **Used in**:
+  - `Order.lineItems` (domain record)
+  - `PlaceOrderCommand.lineItems` (command)
+  - `OrderPlacedEvent.lineItems` (event)
+- **Mapped from**:
+  - `LineItemRequest` → `LineItem` (via `LineItemMapper`)
+  - `OrderLineItemEntity` → `LineItem` (via `OrderAggregateMapper`)
+
+### 3. OrderLineItemEntity (Persistence Entity)
+- **Location**: `com.ead.payments.orders.OrderLineItemEntity`
+- **Relationship**: `@ManyToOne OrderAggregate`
+- **Stored in**: `orders.line_items` table
+- **Created from**: `LineItem` (in `OrderAggregate` constructor)
+
+### 4. Mapping Chain
+```
+LineItemRequest → LineItemMapper → LineItem
+LineItem → OrderAggregate constructor → OrderLineItemEntity
+OrderLineItemEntity → OrderAggregateMapper → LineItem
+LineItem → LineItemResponseMapper → LineItemResponse
+```
+
+---
+
+## Package Structure
+
+```
+com.ead.payments.orders/
+├── [Domain Layer]
+│   ├── LineItem.java (record)
+│   ├── Order.java (record)
+│   ├── OrderAggregate.java (JPA Entity)
+│   └── OrderLineItemEntity.java (JPA Entity)
+│
+├── place/
+│   ├── [Command]
+│   │   └── PlaceOrderCommand.java
+│   │
+│   ├── request/
+│   │   ├── PlaceOrderRequestV1.java
+│   │   ├── PlaceOrderRequestV2.java
+│   │   └── LineItemRequest.java
+│   │
+│   ├── response/
+│   │   ├── PlaceOrderResponseV1.java
+│   │   └── PlaceOrderResponseV2.java
+│   │
+│   └── mapping/
+│       ├── LineItemMapper.java
+│       ├── PlaceOrderCommandMapper.java
+│       └── PlaceOrderResponseMapper.java
+│
+├── search/
+│   ├── SearchOrderResponse.java
+│   └── mapping/
+│       └── SearchOrderResponseMapper.java
+│
+├── response/
+│   └── LineItemResponse.java ⭐ SINGLE SOURCE
+│
+└── mapping/
+    ├── OrderAggregateMapper.java
+    └── LineItemResponseMapper.java ⭐ SINGLE MAPPER
+```
+
+---
+
+## Summary
+
+1. **API Boundary**: Versioned request/response DTOs (`V1`, `V2`)
+2. **Domain Model**: Single, unversioned domain model (`Order`, `LineItem`)
+3. **Persistence**: JPA entities (`OrderAggregate`, `OrderLineItemEntity`)
+4. **Mapping**: MapStruct mappers convert between layers
+5. **LineItemResponse**: Single shared response DTO used by both place and search endpoints
+6. **LineItemResponseMapper**: Single mapper for converting `LineItem` → `LineItemResponse`

--- a/src/main/java/com/ead/payments/orders/LineItem.java
+++ b/src/main/java/com/ead/payments/orders/LineItem.java
@@ -1,0 +1,23 @@
+package com.ead.payments.orders;
+
+import com.google.common.base.Preconditions;
+
+public record LineItem(
+    String name,
+    int quantity,
+    Long unitPrice,  // in minor units (e.g., cents)
+    String reference  // nullable
+) {
+    public LineItem {
+        Preconditions.checkArgument(name != null && !name.isBlank(), 
+            "Line item name is required");
+        Preconditions.checkArgument(quantity > 0, 
+            "Line item quantity must be greater than 0");
+        Preconditions.checkArgument(unitPrice != null && unitPrice >= 0, 
+            "Line item unit price must be non-negative");
+    }
+    
+    public Long lineTotal() {
+        return unitPrice * quantity;
+    }
+}

--- a/src/main/java/com/ead/payments/orders/Order.java
+++ b/src/main/java/com/ead/payments/orders/Order.java
@@ -1,6 +1,7 @@
 package com.ead.payments.orders;
 
 import java.util.Currency;
+import java.util.List;
 import java.util.UUID;
 
 public record Order(
@@ -8,7 +9,8 @@ public record Order(
         long version,
         OrderStatus status,
         Currency currency,
-        Long amount
+        Long amount,
+        List<LineItem> lineItems  // NEW
 ) {
 
     public enum OrderStatus {

--- a/src/main/java/com/ead/payments/orders/OrderAggregate.java
+++ b/src/main/java/com/ead/payments/orders/OrderAggregate.java
@@ -16,7 +16,9 @@ import org.springframework.data.domain.AbstractAggregateRoot;
 import org.springframework.data.domain.Persistable;
 import org.springframework.security.authorization.method.AuthorizeReturnObject;
 
+import java.util.ArrayList;
 import java.util.Currency;
+import java.util.List;
 import java.util.UUID;
 
 import static com.ead.payments.orders.Order.OrderStatus;
@@ -50,23 +52,59 @@ public class OrderAggregate extends AbstractAggregateRoot<OrderAggregate> implem
     @NotNull
     private Long amount;
 
-    public OrderAggregate(PlaceOrderCommand command) {
-        Preconditions.checkNotNull(command.currency(), "The currency is required");
-        Preconditions.checkNotNull(command.amount(), "The amount is required");
-        Preconditions.checkArgument(command.amount() > 0, "The amount must be greater than 0");
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderLineItemEntity> lineItems = new ArrayList<>();
 
+    public OrderAggregate(PlaceOrderCommand command) {
+        // Existing validations
+        Preconditions.checkNotNull(command.currency(), "The currency is required");
+        Preconditions.checkNotNull(command.lineItems(), "Line items are required");
+        // Note: Line items can be empty for V1 orders
+        
+        // Validate each line item
+        for (LineItem item : command.lineItems()) {
+            Preconditions.checkArgument(item.quantity() > 0, 
+                "Line item quantity must be greater than 0");
+            Preconditions.checkArgument(item.unitPrice() != null && item.unitPrice() >= 0, 
+                "Line item unit price must be non-negative");
+        }
+        
+        // Convert LineItems to entities
+        this.lineItems = command.lineItems().stream()
+            .map(item -> new OrderLineItemEntity(this, item))
+            .toList();
+        
+        // Compute total from line items (if any)
+        Long computedTotal = lineItems.stream()
+            .mapToLong(OrderLineItemEntity::getLineTotal)
+            .sum();
+        
+        // Validate that computed total matches the provided amount (if provided)
+        if (command.amount() != null && !command.lineItems().isEmpty()) {
+            Preconditions.checkArgument(
+                computedTotal.equals(command.amount()),
+                "Line items total (%s) does not match provided amount (%s)",
+                computedTotal,
+                command.amount()
+            );
+        }
+        
+        // For V1 orders (empty line items), use the provided amount
+        // For V2 orders, use computed total from line items
+        this.amount = command.amount() != null ? command.amount() : computedTotal;
+        Preconditions.checkArgument(this.amount > 0, "The amount must be greater than 0");
+        
         this.id = command.id();
-        //this.version = 0L;
         this.status = OrderStatus.PLACED;
         this.currency = command.currency();
-        this.amount = command.amount();
-
+        
         registerEvent(new OrderPlacedEvent(
-                command.id(),
-                version,
-                status,
-                command.currency(),
-                command.amount()
+            command.id(),
+            version,
+            status,
+            command.currency(),
+            this.amount,
+            command.lineItems()  // Include line items in event
         ));
     }
 

--- a/src/main/java/com/ead/payments/orders/OrderAggregateMapper.java
+++ b/src/main/java/com/ead/payments/orders/OrderAggregateMapper.java
@@ -1,11 +1,33 @@
 package com.ead.payments.orders;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface OrderAggregateMapper {
-
-
+    
+    /**
+     * Maps OrderAggregate to Order domain record.
+     * MapStruct automatically handles simple field mappings.
+     */
+    @Mapping(target = "lineItems", source = "lineItems")
     Order toOrder(OrderAggregate orderAggregate);
-
+    
+    /**
+     * Maps OrderLineItemEntity to LineItem value object.
+     * MapStruct automatically generates this mapping.
+     */
+    @Mapping(target = "name", source = "name")
+    @Mapping(target = "quantity", source = "quantity")
+    @Mapping(target = "unitPrice", source = "unitPrice")
+    @Mapping(target = "reference", source = "reference")
+    LineItem toLineItem(OrderLineItemEntity entity);
+    
+    /**
+     * Maps list of OrderLineItemEntity to list of LineItem.
+     * MapStruct automatically handles list mapping.
+     */
+    List<LineItem> toLineItems(List<OrderLineItemEntity> entities);
 }

--- a/src/main/java/com/ead/payments/orders/OrderLineItemEntity.java
+++ b/src/main/java/com/ead/payments/orders/OrderLineItemEntity.java
@@ -1,0 +1,46 @@
+package com.ead.payments.orders;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "line_items", schema = "orders")
+@Data
+@NoArgsConstructor
+public class OrderLineItemEntity {
+    
+    @Id
+    @GeneratedValue
+    private UUID id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private OrderAggregate order;
+    
+    @Column(nullable = false)
+    private String name;
+    
+    @Column(nullable = false)
+    private Integer quantity;
+    
+    @Column(name = "unit_price_minor_units", nullable = false)
+    private Long unitPrice;
+    
+    @Column
+    private String reference;
+    
+    public OrderLineItemEntity(OrderAggregate order, LineItem lineItem) {
+        this.order = order;
+        this.name = lineItem.name();
+        this.quantity = lineItem.quantity();
+        this.unitPrice = lineItem.unitPrice();
+        this.reference = lineItem.reference();
+    }
+    
+    public Long getLineTotal() {
+        return unitPrice * quantity;
+    }
+}

--- a/src/main/java/com/ead/payments/orders/OrderPlacedEvent.java
+++ b/src/main/java/com/ead/payments/orders/OrderPlacedEvent.java
@@ -7,6 +7,7 @@ import lombok.Value;
 import org.springframework.modulith.events.Externalized;
 
 import java.util.Currency;
+import java.util.List;
 import java.util.UUID;
 
 @Value
@@ -20,5 +21,6 @@ public class OrderPlacedEvent {
     Order.OrderStatus status;
     Currency currency;
     Long amount;
+    List<LineItem> lineItems;  // NEW
 
 }

--- a/src/main/java/com/ead/payments/orders/mapping/LineItemResponseMapper.java
+++ b/src/main/java/com/ead/payments/orders/mapping/LineItemResponseMapper.java
@@ -1,0 +1,26 @@
+package com.ead.payments.orders.mapping;
+
+import com.ead.payments.orders.LineItem;
+import com.ead.payments.orders.response.LineItemResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface LineItemResponseMapper {
+    
+    /**
+     * Maps LineItem domain to LineItemResponse DTO.
+     */
+    @Mapping(target = "name", source = "name")
+    @Mapping(target = "quantity", source = "quantity")
+    @Mapping(target = "unitPrice", source = "unitPrice")
+    @Mapping(target = "reference", source = "reference")
+    LineItemResponse from(LineItem lineItem);
+    
+    /**
+     * Maps list of LineItem domain to list of LineItemResponse DTO.
+     */
+    List<LineItemResponse> from(List<LineItem> lineItems);
+}

--- a/src/main/java/com/ead/payments/orders/place/PlaceOrderCommand.java
+++ b/src/main/java/com/ead/payments/orders/place/PlaceOrderCommand.java
@@ -1,11 +1,15 @@
 package com.ead.payments.orders.place;
 
+import com.ead.payments.orders.LineItem;
+
 import java.util.Currency;
+import java.util.List;
 import java.util.UUID;
 
 public record PlaceOrderCommand(
         UUID id,
         Currency currency,
-        Long amount
+        Long amount,  // Keep for backward compatibility during transition
+        List<LineItem> lineItems  // NEW
 ) {
 }

--- a/src/main/java/com/ead/payments/orders/place/PlaceOrderController.java
+++ b/src/main/java/com/ead/payments/orders/place/PlaceOrderController.java
@@ -1,5 +1,11 @@
 package com.ead.payments.orders.place;
 
+import com.ead.payments.orders.place.mapping.PlaceOrderCommandMapper;
+import com.ead.payments.orders.place.mapping.PlaceOrderResponseMapper;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV1;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV2;
+import com.ead.payments.orders.place.response.PlaceOrderResponseV1;
+import com.ead.payments.orders.place.response.PlaceOrderResponseV2;
 import io.micrometer.observation.annotation.Observed;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.validation.Valid;
@@ -21,25 +27,50 @@ import java.util.UUID;
 public class PlaceOrderController {
 
     PlaceOrderService placeOrderService;
+    PlaceOrderCommandMapper commandMapper;
+    PlaceOrderResponseMapper responseMapper;
 
+    /**
+     * V1 endpoint: Explicit version header required.
+     * Method overloading allows same method name with different parameter types.
+     */
     @PostMapping(headers = "version=1.0.0")
     @ResponseStatus(HttpStatus.CREATED)
-    @Observed(name = "http.orders.create", contextualName = "POST /orders")
-    public PlaceOrderResponse placeOrder(@RequestBody @Valid @NotNull PlaceOrderRequest request) {
-
+    @Observed(
+        name = "http.orders.create",
+        contextualName = "POST /orders",
+        lowCardinalityKeyValues = {"version", "1.0.0"}
+    )
+    public PlaceOrderResponseV1 placeOrder(
+            @RequestBody @Valid @NotNull PlaceOrderRequestV1 request) {
+        
         UUID orderId = UUID.randomUUID();
-
-        // TODO: make sure to allow the client of this API to place an order with its own ID
-        var order = placeOrderService.handle(new PlaceOrderCommand(
-                orderId,
-                request.currency(),
-                request.amount()
-        ));
-
-        return new PlaceOrderResponse(
-            order.id(),
-            order.currency(),
-            order.amount()
-        );
+        var command = commandMapper.toCommand(request, orderId);
+        var order = placeOrderService.handle(command);
+        
+        return responseMapper.toResponseV1(order);
+    }
+    
+    /**
+     * V2 endpoint: Default (no version header required).
+     * Spring will route requests without version header to this method.
+     * Method overloading with different parameter type (PlaceOrderRequestV2).
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Observed(
+        name = "http.orders.create",
+        contextualName = "POST /orders",
+        lowCardinalityKeyValues = {"version", "2.0.0"}
+    )
+    public PlaceOrderResponseV2 placeOrder(
+            @RequestBody @Valid @NotNull PlaceOrderRequestV2 request) {
+        
+        UUID orderId = UUID.randomUUID();
+        // MapStruct automatically uses LineItemMapper (from 'uses' parameter) to convert lineItems
+        var command = commandMapper.toCommand(request, orderId);
+        var order = placeOrderService.handle(command);
+        
+        return responseMapper.toResponseV2(order);
     }
 }

--- a/src/main/java/com/ead/payments/orders/place/mapping/LineItemMapper.java
+++ b/src/main/java/com/ead/payments/orders/place/mapping/LineItemMapper.java
@@ -1,0 +1,28 @@
+package com.ead.payments.orders.place.mapping;
+
+import com.ead.payments.orders.LineItem;
+import com.ead.payments.orders.place.request.LineItemRequest;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface LineItemMapper {
+    
+    /**
+     * Maps LineItemRequest DTO to domain LineItem.
+     * MapStruct automatically generates implementation for this mapping.
+     */
+    @Mapping(target = "name", source = "name")
+    @Mapping(target = "quantity", source = "quantity")
+    @Mapping(target = "unitPrice", source = "unitPrice")
+    @Mapping(target = "reference", source = "reference")
+    LineItem toLineItem(LineItemRequest dto);
+    
+    /**
+     * Maps list of LineItemRequest DTOs to list of domain LineItems.
+     * MapStruct automatically handles list mapping by calling toLineItem for each element.
+     */
+    List<LineItem> toLineItems(List<LineItemRequest> dtos);
+}

--- a/src/main/java/com/ead/payments/orders/place/mapping/PlaceOrderCommandMapper.java
+++ b/src/main/java/com/ead/payments/orders/place/mapping/PlaceOrderCommandMapper.java
@@ -1,0 +1,52 @@
+package com.ead.payments.orders.place.mapping;
+
+import com.ead.payments.orders.LineItem;
+import com.ead.payments.orders.place.PlaceOrderCommand;
+import com.ead.payments.orders.place.request.LineItemRequest;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV1;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV2;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = {LineItemMapper.class})
+public interface PlaceOrderCommandMapper {
+    
+    /**
+     * Maps V1 request to command. Uses empty list for line items.
+     * MapStruct automatically generates the implementation.
+     * No validation - validation happens in OrderAggregate constructor.
+     */
+    @Mapping(target = "id", source = "orderId")
+    @Mapping(target = "currency", source = "request.currency")
+    @Mapping(target = "amount", source = "request.amount")
+    @Mapping(target = "lineItems", expression = "java(java.util.List.of())")
+    PlaceOrderCommand toCommand(PlaceOrderRequestV1 request, UUID orderId);
+    
+    /**
+     * Maps V2 request to command. 
+     * MapStruct automatically uses LineItemMapper (from 'uses') to convert lineItems.
+     * Amount is computed from line items using an expression.
+     */
+    @Mapping(target = "id", source = "orderId")
+    @Mapping(target = "currency", source = "request.currency")
+    @Mapping(target = "amount", expression = "java(computeTotalFromLineItems(request.lineItems()))")
+    @Mapping(target = "lineItems", source = "request.lineItems")
+    PlaceOrderCommand toCommand(PlaceOrderRequestV2 request, UUID orderId);
+    
+    /**
+     * Helper method to compute total from line items.
+     * Used in @Mapping expression for V2 mapping.
+     */
+    default Long computeTotalFromLineItems(List<LineItemRequest> lineItems) {
+        if (lineItems == null || lineItems.isEmpty()) {
+            return 0L;
+        }
+        return lineItems.stream()
+            .mapToLong(item -> item.unitPrice() * item.quantity())
+            .sum();
+    }
+}

--- a/src/main/java/com/ead/payments/orders/place/mapping/PlaceOrderResponseMapper.java
+++ b/src/main/java/com/ead/payments/orders/place/mapping/PlaceOrderResponseMapper.java
@@ -1,0 +1,30 @@
+package com.ead.payments.orders.place.mapping;
+
+import com.ead.payments.orders.Order;
+import com.ead.payments.orders.mapping.LineItemResponseMapper;
+import com.ead.payments.orders.place.response.PlaceOrderResponseV1;
+import com.ead.payments.orders.place.response.PlaceOrderResponseV2;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = {LineItemResponseMapper.class})
+public interface PlaceOrderResponseMapper {
+    
+    /**
+     * Maps Order domain to V1 response (without line items).
+     */
+    @Mapping(target = "id", source = "id")
+    @Mapping(target = "currency", source = "currency")
+    @Mapping(target = "amount", source = "amount")
+    PlaceOrderResponseV1 toResponseV1(Order order);
+    
+    /**
+     * Maps Order domain to V2 response (with line items).
+     * MapStruct automatically uses LineItemResponseMapper (from 'uses') to convert lineItems.
+     */
+    @Mapping(target = "id", source = "id")
+    @Mapping(target = "currency", source = "currency")
+    @Mapping(target = "amount", source = "amount")
+    @Mapping(target = "lineItems", source = "lineItems")
+    PlaceOrderResponseV2 toResponseV2(Order order);
+}

--- a/src/main/java/com/ead/payments/orders/place/request/LineItemRequest.java
+++ b/src/main/java/com/ead/payments/orders/place/request/LineItemRequest.java
@@ -1,0 +1,13 @@
+package com.ead.payments.orders.place.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record LineItemRequest(
+    @NotBlank String name,
+    @Min(1) int quantity,
+    @NotNull @Min(0L) Long unitPrice,
+    String reference  // nullable, no validation needed
+) {
+}

--- a/src/main/java/com/ead/payments/orders/place/request/PlaceOrderRequestV1.java
+++ b/src/main/java/com/ead/payments/orders/place/request/PlaceOrderRequestV1.java
@@ -1,12 +1,13 @@
-package com.ead.payments.orders.place;
+package com.ead.payments.orders.place.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Currency;
 
-public record PlaceOrderRequest(
+public record PlaceOrderRequestV1(
         @NotNull Currency currency,
         @NotNull @Min(0L) Long amount
 ) {
+    // This is the current PlaceOrderRequest renamed
 }

--- a/src/main/java/com/ead/payments/orders/place/request/PlaceOrderRequestV2.java
+++ b/src/main/java/com/ead/payments/orders/place/request/PlaceOrderRequestV2.java
@@ -1,0 +1,16 @@
+package com.ead.payments.orders.place.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.Currency;
+import java.util.List;
+
+public record PlaceOrderRequestV2(
+    @NotNull Currency currency,
+    @NotNull @Size(min = 1, max = 100) @Valid List<LineItemRequest> lineItems,
+    @Min(0L) Long amount  // Optional: for validation if provided
+) {
+}

--- a/src/main/java/com/ead/payments/orders/place/response/PlaceOrderResponseV1.java
+++ b/src/main/java/com/ead/payments/orders/place/response/PlaceOrderResponseV1.java
@@ -1,4 +1,4 @@
-package com.ead.payments.orders.place;
+package com.ead.payments.orders.place.response;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class PlaceOrderResponse {
+public class PlaceOrderResponseV1 {
 
     private UUID id;
     private @NotBlank Currency currency;

--- a/src/main/java/com/ead/payments/orders/place/response/PlaceOrderResponseV2.java
+++ b/src/main/java/com/ead/payments/orders/place/response/PlaceOrderResponseV2.java
@@ -1,7 +1,7 @@
-package com.ead.payments.orders.search;
+package com.ead.payments.orders.place.response;
 
 import com.ead.payments.orders.response.LineItemResponse;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -14,11 +14,11 @@ import java.util.UUID;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class SearchOrderResponse {
+public class PlaceOrderResponseV2 {
 
-    private @NotNull UUID id;
-    private @NotNull @Min(0L) Long version;
-    private @NotNull Currency currency;
+    private UUID id;
+    private @NotBlank Currency currency;
     private @NotNull Long amount;
     private @NotNull List<LineItemResponse> lineItems;
+
 }

--- a/src/main/java/com/ead/payments/orders/response/LineItemResponse.java
+++ b/src/main/java/com/ead/payments/orders/response/LineItemResponse.java
@@ -1,0 +1,13 @@
+package com.ead.payments.orders.response;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record LineItemResponse(
+    @NotBlank String name,
+    @Min(1) int quantity,
+    @NotNull @Min(0L) Long unitPrice,
+    String reference  // nullable
+) {
+}

--- a/src/main/java/com/ead/payments/orders/search/SearchOrderController.java
+++ b/src/main/java/com/ead/payments/orders/search/SearchOrderController.java
@@ -1,5 +1,6 @@
 package com.ead.payments.orders.search;
 
+import com.ead.payments.orders.search.mapping.SearchOrderResponseMapper;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.validation.constraints.NotNull;
 import java.util.Optional;
@@ -21,16 +22,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class SearchOrderController {
 
     SearchOrderService searchOrderService;
+    SearchOrderResponseMapper responseMapper;
 
     @GetMapping(path = "/{order_id}", headers = "version=1.0.0")
     @ResponseStatus(HttpStatus.OK)
     public Optional<SearchOrderResponse> searchOrder(@PathVariable("order_id") @NotNull UUID orderId) {
         return searchOrderService.search(orderId)
-                .map(order -> new SearchOrderResponse(
-                        order.id(),
-                        order.version(),
-                        order.currency(),
-                        order.amount()
-                ));
+                .map(responseMapper::from);
     }
 }

--- a/src/main/java/com/ead/payments/orders/search/SearchOrderService.java
+++ b/src/main/java/com/ead/payments/orders/search/SearchOrderService.java
@@ -1,6 +1,7 @@
 package com.ead.payments.orders.search;
 
 import com.ead.payments.orders.Order;
+import com.ead.payments.orders.OrderAggregateMapper;
 import com.ead.payments.orders.OrderRepository;
 import java.util.Optional;
 import java.util.UUID;
@@ -12,15 +13,10 @@ import org.springframework.stereotype.Service;
 public class SearchOrderService {
 
     final OrderRepository orderRepository;
+    final OrderAggregateMapper orderAggregateMapper;
 
     public Optional<Order> search(UUID orderId) {
         return orderRepository.findById(orderId)
-                .map(aggregate -> new Order(
-                        aggregate.getId(),
-                        aggregate.getVersion(),
-                        aggregate.getStatus(),
-                        aggregate.getCurrency(),
-                        aggregate.getAmount()
-                ));
+                .map(orderAggregateMapper::toOrder);
     }
 }

--- a/src/main/java/com/ead/payments/orders/search/mapping/SearchOrderResponseMapper.java
+++ b/src/main/java/com/ead/payments/orders/search/mapping/SearchOrderResponseMapper.java
@@ -1,0 +1,22 @@
+package com.ead.payments.orders.search.mapping;
+
+import com.ead.payments.orders.Order;
+import com.ead.payments.orders.mapping.LineItemResponseMapper;
+import com.ead.payments.orders.search.SearchOrderResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = {LineItemResponseMapper.class})
+public interface SearchOrderResponseMapper {
+    
+    /**
+     * Maps Order domain to SearchOrderResponse.
+     * MapStruct automatically uses LineItemResponseMapper (from 'uses') to convert lineItems.
+     */
+    @Mapping(target = "id", source = "id")
+    @Mapping(target = "version", source = "version")
+    @Mapping(target = "currency", source = "currency")
+    @Mapping(target = "amount", source = "amount")
+    @Mapping(target = "lineItems", source = "lineItems")
+    SearchOrderResponse from(Order order);
+}

--- a/src/main/resources/db/migration/V20251115_1219__add_line_items.sql
+++ b/src/main/resources/db/migration/V20251115_1219__add_line_items.sql
@@ -1,0 +1,17 @@
+-- Create line_items table
+CREATE TABLE IF NOT EXISTS orders.line_items (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    order_id UUID NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    quantity INTEGER NOT NULL CHECK (quantity > 0),
+    unit_price_minor_units BIGINT NOT NULL CHECK (unit_price_minor_units >= 0),
+    reference VARCHAR(255),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (order_id) REFERENCES orders.orders(order_id) ON DELETE CASCADE
+);
+
+-- Index for efficient order lookup
+CREATE INDEX IF NOT EXISTS idx_line_items_order_id ON orders.line_items(order_id);
+
+-- Note: orders.amount remains for query efficiency (denormalized)
+-- Consistency ensured via application logic

--- a/src/test/java/com/ead/payments/inventory/InventoryControllerTest.java
+++ b/src/test/java/com/ead/payments/inventory/InventoryControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.modulith.test.Scenario;
 
 import java.time.Duration;
 import java.util.Currency;
+import java.util.List;
 import java.util.UUID;
 
 import static com.ead.payments.orders.Order.OrderStatus.PLACED;
@@ -27,7 +28,8 @@ class InventoryControllerTest {
                 0L,
                 PLACED,
                 Currency.getInstance("USD"),
-                100L
+                100L,
+                List.of()  // Empty line items for test
         );
 
         // When

--- a/src/test/java/com/ead/payments/observability/ActuatorControllerTest.java
+++ b/src/test/java/com/ead/payments/observability/ActuatorControllerTest.java
@@ -3,7 +3,7 @@ package com.ead.payments.observability;
 import com.ead.payments.SpringBootIntegrationTest;
 import com.ead.payments.logging.CorrelationId;
 import com.ead.payments.mocks.TestMocks;
-import com.ead.payments.orders.place.PlaceOrderRequest;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV1;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
@@ -102,7 +102,7 @@ public class ActuatorControllerTest extends SpringBootIntegrationTest {
                 .toAcceptTheAuthorizationWith(correlationId);
 
         // given: trigger the metric by placing an order
-        var request = new PlaceOrderRequest(Currency.getInstance("USD"), 100L);
+        var request = new PlaceOrderRequestV1(Currency.getInstance("USD"), 100L);
         mockMvc.perform(
                         post("/orders")
                                 .header("version", "1.0.0")
@@ -121,4 +121,3 @@ public class ActuatorControllerTest extends SpringBootIntegrationTest {
                 .andExpect(jsonPath("$.measurements", is(notNullValue())));
     }
 }
-

--- a/src/test/java/com/ead/payments/orders/cancel/CancelOrderControllerTest.java
+++ b/src/test/java/com/ead/payments/orders/cancel/CancelOrderControllerTest.java
@@ -3,8 +3,8 @@ package com.ead.payments.orders.cancel;
 import com.ead.payments.SpringBootIntegrationTest;
 import com.ead.payments.logging.CorrelationId;
 import com.ead.payments.mocks.TestMocks;
-import com.ead.payments.orders.place.PlaceOrderRequest;
-import com.ead.payments.orders.place.PlaceOrderResponse;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV1;
+import com.ead.payments.orders.place.response.PlaceOrderResponseV1;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,7 +40,7 @@ class CancelOrderControllerTest extends SpringBootIntegrationTest {
                 .toAcceptTheAuthorizationWith(expectedCorrelationId);
 
         // given: a valid place order request
-        var request = new PlaceOrderRequest(Currency.getInstance("USD"), 100L);
+        var request = new PlaceOrderRequestV1(Currency.getInstance("USD"), 100L);
 
         // and: the place order request is made
         var orderPlacedResponse = mockMvc.perform(post("/orders")
@@ -52,7 +52,7 @@ class CancelOrderControllerTest extends SpringBootIntegrationTest {
 
         // and: the order id is extracted from the response
         var orderId = objectMapper.readValue(orderPlacedResponse.andReturn().getResponse().getContentAsString(),
-                PlaceOrderResponse.class).getId();
+                PlaceOrderResponseV1.class).getId();
 
         // when: the cancel order request is made
         var response = mockMvc.perform(post("/orders/" + orderId + "/cancel")

--- a/src/test/java/com/ead/payments/orders/events/EventsControllerTest.java
+++ b/src/test/java/com/ead/payments/orders/events/EventsControllerTest.java
@@ -3,8 +3,8 @@ package com.ead.payments.orders.events;
 import com.ead.payments.SpringBootIntegrationTest;
 import com.ead.payments.logging.CorrelationId;
 import com.ead.payments.mocks.TestMocks;
-import com.ead.payments.orders.place.PlaceOrderRequest;
-import com.ead.payments.orders.place.PlaceOrderResponse;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV1;
+import com.ead.payments.orders.place.response.PlaceOrderResponseV1;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +49,7 @@ class EventsControllerTest extends SpringBootIntegrationTest {
     void shouldAllowToRetrieveAllEventsForWhenReadingAnOrderHistory() throws Exception {
 
         // given: a valid place order request
-        var request = new PlaceOrderRequest(Currency.getInstance("USD"), 100L);
+        var request = new PlaceOrderRequestV1(Currency.getInstance("USD"), 100L);
 
         // and: the place order request is made
         var orderPlacedResponse = mockMvc.perform(post("/orders")
@@ -61,7 +61,7 @@ class EventsControllerTest extends SpringBootIntegrationTest {
 
         // and: the order id is extracted from the response
         var orderId = objectMapper.readValue(orderPlacedResponse.andReturn().getResponse().getContentAsString(),
-                PlaceOrderResponse.class).getId();
+                PlaceOrderResponseV1.class).getId();
 
         // when: the get order events request is made
         var response = mockMvc.perform(get("/orders/" + orderId + "/events")
@@ -82,7 +82,7 @@ class EventsControllerTest extends SpringBootIntegrationTest {
     @DisplayName("Should allow to retrieve a specific event for when reading an order history")
     void shouldAllowToRetrieveASpecificEventWhenReadingAnOrderHistory() throws Exception {
         // given: a valid place order request
-        var request = new PlaceOrderRequest(Currency.getInstance("USD"), 100L);
+        var request = new PlaceOrderRequestV1(Currency.getInstance("USD"), 100L);
 
         // and: the place order request is made
         var orderPlacedResponse = mockMvc.perform(post("/orders")
@@ -94,7 +94,7 @@ class EventsControllerTest extends SpringBootIntegrationTest {
 
         // and: the order id is extracted from the response
         var orderId = objectMapper.readValue(orderPlacedResponse.andReturn().getResponse().getContentAsString(),
-                PlaceOrderResponse.class).getId();
+                PlaceOrderResponseV1.class).getId();
 
         // and: the get order events request is made to get the event id
         var eventsResponse = mockMvc.perform(get("/orders/" + orderId + "/events")

--- a/src/test/java/com/ead/payments/orders/place/PlaceInvalidOrderControllerTest.java
+++ b/src/test/java/com/ead/payments/orders/place/PlaceInvalidOrderControllerTest.java
@@ -1,5 +1,7 @@
 package com.ead.payments.orders.place;
 
+import com.ead.payments.orders.place.request.PlaceOrderRequestV1;
+
 import com.ead.payments.SpringBootIntegrationTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -15,7 +17,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class PlaceInvalidOrderControllerTet extends SpringBootIntegrationTest {
+public class PlaceInvalidOrderControllerTest extends SpringBootIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -29,7 +31,7 @@ public class PlaceInvalidOrderControllerTet extends SpringBootIntegrationTest {
     public void shouldNotAllowToPlaceTheOrderWhenTheOrderIsInvalid() throws Exception {
 
         // given: an invalid place order request
-        PlaceOrderRequest placeOrderRequest = new PlaceOrderRequest(
+        PlaceOrderRequestV1 placeOrderRequest = new PlaceOrderRequestV1(
                 Currency.getInstance("USD"),
                 -1200L
         );

--- a/src/test/java/com/ead/payments/orders/place/PlaceOrderUnauthorizedControllerTest.java
+++ b/src/test/java/com/ead/payments/orders/place/PlaceOrderUnauthorizedControllerTest.java
@@ -1,5 +1,7 @@
 package com.ead.payments.orders.place;
 
+import com.ead.payments.orders.place.request.PlaceOrderRequestV1;
+
 import com.ead.payments.SpringBootIntegrationTest;
 import com.ead.payments.logging.CorrelationId;
 import com.ead.payments.mocks.TestMocks;
@@ -36,7 +38,7 @@ public class PlaceOrderUnauthorizedControllerTest extends SpringBootIntegrationT
                 .toRejectTheAuthorizationWith(expectedCorrelationId);
 
         // given: a valid place order request
-        var request = new PlaceOrderRequest(Currency.getInstance("USD"), 100L);
+        var request = new PlaceOrderRequestV1(Currency.getInstance("USD"), 100L);
 
         // when: the place order request is made
         var response = mockMvc.perform(post("/orders")

--- a/src/test/java/com/ead/payments/orders/place/PlaceOrdersControllerTest.java
+++ b/src/test/java/com/ead/payments/orders/place/PlaceOrdersControllerTest.java
@@ -1,5 +1,9 @@
 package com.ead.payments.orders.place;
 
+import com.ead.payments.orders.place.request.LineItemRequest;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV1;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV2;
+
 import com.ead.payments.SpringBootIntegrationTest;
 import com.ead.payments.logging.CorrelationId;
 import com.ead.payments.mocks.TestMocks;
@@ -12,6 +16,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Currency;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -39,7 +44,7 @@ class PlaceOrdersControllerTest extends SpringBootIntegrationTest {
                 .toAcceptTheAuthorizationWith(expectedCorrelationId);
 
         // given: a valid place order request
-        var request = new PlaceOrderRequest(Currency.getInstance("USD"), 100L);
+        var request = new PlaceOrderRequestV1(Currency.getInstance("USD"), 100L);
 
         // when: the place order request is made
         var response = mockMvc.perform(post("/orders")
@@ -54,5 +59,52 @@ class PlaceOrdersControllerTest extends SpringBootIntegrationTest {
                 .andExpectAll(jsonPath("$.id", is(notNullValue())),
                         jsonPath("$.currency", is("USD")),
                         jsonPath("$.amount", is(100)));
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = "USER")
+    @DisplayName("Should allow to place an order when line items are provided")
+    void shouldAllowToPlaceAnOrderWhenLineItemsAreProvided() throws Exception {
+
+        //setup: issuer service with an authorized response
+        CorrelationId expectedCorrelationId = CorrelationId.random();
+        TestMocks.setup(issuerService())
+                .toAcceptTheAuthorizationWith(expectedCorrelationId);
+
+        // given: a valid place order request with line items (V2)
+        var request = new PlaceOrderRequestV2(
+                Currency.getInstance("USD"),
+                List.of(
+                        new LineItemRequest("Wireless Bluetooth Headphones", 2, 1000L, "SKU-HEADPHONE-001"),
+                        new LineItemRequest("USB-C Charging Cable", 1, 2000L, "SKU-CABLE-002")
+                ),
+                null  // amount not provided, should be computed from line items
+        );
+
+        // when: the place order request is made (no version header defaults to V2)
+        var response = mockMvc.perform(post("/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Correlation-ID", expectedCorrelationId)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then: the response is 201 with line items
+        // Expected total: (2 * 1000) + (1 * 2000) = 4000
+        response.andDo(print())
+                .andExpect(status().isCreated())
+                .andExpectAll(
+                        jsonPath("$.id", is(notNullValue())),
+                        jsonPath("$.currency", is("USD")),
+                        jsonPath("$.amount", is(4000)),
+                        jsonPath("$.lineItems", is(notNullValue())),
+                        jsonPath("$.lineItems.length()", is(2)),
+                        jsonPath("$.lineItems[0].name", is("Wireless Bluetooth Headphones")),
+                        jsonPath("$.lineItems[0].quantity", is(2)),
+                        jsonPath("$.lineItems[0].unitPrice", is(1000)),
+                        jsonPath("$.lineItems[0].reference", is("SKU-HEADPHONE-001")),
+                        jsonPath("$.lineItems[1].name", is("USB-C Charging Cable")),
+                        jsonPath("$.lineItems[1].quantity", is(1)),
+                        jsonPath("$.lineItems[1].unitPrice", is(2000)),
+                        jsonPath("$.lineItems[1].reference", is("SKU-CABLE-002"))
+                );
     }
 }

--- a/src/test/java/com/ead/payments/orders/search/SearchOrderControllerTest.java
+++ b/src/test/java/com/ead/payments/orders/search/SearchOrderControllerTest.java
@@ -3,8 +3,8 @@ package com.ead.payments.orders.search;
 import com.ead.payments.SpringBootIntegrationTest;
 import com.ead.payments.logging.CorrelationId;
 import com.ead.payments.mocks.TestMocks;
-import com.ead.payments.orders.place.PlaceOrderRequest;
-import com.ead.payments.orders.place.PlaceOrderResponse;
+import com.ead.payments.orders.place.request.PlaceOrderRequestV1;
+import com.ead.payments.orders.place.response.PlaceOrderResponseV1;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ class SearchOrderControllerTest extends SpringBootIntegrationTest {
                 .toAcceptTheAuthorizationWith(expectedCorrelationId);
 
         // given: a valid place order request
-        var request = new PlaceOrderRequest(Currency.getInstance("USD"), 100L);
+        var request = new PlaceOrderRequestV1(Currency.getInstance("USD"), 100L);
 
         // and: the place order request is made
         var orderPlacedResponse = mockMvc.perform(post("/orders")
@@ -54,7 +54,7 @@ class SearchOrderControllerTest extends SpringBootIntegrationTest {
 
         // and: the order id is extracted from the response
         var orderId = objectMapper.readValue(orderPlacedResponse.andReturn().getResponse().getContentAsString(),
-                PlaceOrderResponse.class).getId();
+                PlaceOrderResponseV1.class).getId();
 
         // when: the search order request is made
         var response = mockMvc.perform(get("/orders/" + orderId)


### PR DESCRIPTION
# Add Line Items Support to Place Order API

## Summary

This PR introduces line items support to the Place Order API while maintaining full backward compatibility. The implementation follows a versioned API approach at the boundary layer, with a single, unversioned domain model.

## Key Changes

### 🎯 API Versioning
- **V1 API** (`version=1.0.0` header): Maintains backward compatibility - existing clients continue to work unchanged
- **V2 API** (default, no header required): New version supporting line items with automatic amount computation
- Method overloading in `PlaceOrderController` handles version routing automatically

### 📦 Domain Model
- Introduced `LineItem` value object (record) with validation
- Updated `Order` domain record to include `List<LineItem>`
- Updated `OrderAggregate` JPA entity with `@OneToMany` relationship to `OrderLineItemEntity`
- Added `OrderLineItemEntity` JPA entity for persistence

### 🗄️ Database
- New `orders.line_items` table with foreign key to `orders.orders`
- Database migration: `V20251115_1219__add_line_items.sql`
- Cascade delete ensures line items are removed with orders

### 🔄 Mapping Layer (MapStruct)
- **Request Mapping**:
  - `LineItemMapper`: Converts `LineItemRequest` → `LineItem` (domain)
  - `PlaceOrderCommandMapper`: Maps V1/V2 requests to `PlaceOrderCommand` with dependency injection via `uses`
- **Response Mapping**:
  - `LineItemResponseMapper`: Single mapper for `LineItem` → `LineItemResponse` (shared across endpoints)
  - `PlaceOrderResponseMapper`: Maps `Order` → `PlaceOrderResponseV1/V2`
  - `SearchOrderResponseMapper`: Maps `Order` → `SearchOrderResponse`
  - `OrderAggregateMapper`: Maps `OrderAggregate` → `Order` (including line items)

### 📝 DTOs
- **Request DTOs** (`com.ead.payments.orders.place.request`):
  - `PlaceOrderRequestV1`: Renamed from `PlaceOrderRequest` (backward compatible)
  - `PlaceOrderRequestV2`: New version with `List<LineItemRequest>`
  - `LineItemRequest`: Request DTO for line items
- **Response DTOs**:
  - `PlaceOrderResponseV1`: Response without line items
  - `PlaceOrderResponseV2`: Response with `List<LineItemResponse>`
  - `SearchOrderResponse`: Updated to include `List<LineItemResponse>`
  - `LineItemResponse`: **Single shared response DTO** in `com.ead.payments.orders.response` (used by both place and search endpoints)

### 🎨 Package Structure
- Reorganized DTOs into `request` and `response` sub-packages
- Consolidated `LineItemResponse` to a single location (`com.ead.payments.orders.response`)
- All mappers use dependency injection via MapStruct's `uses` parameter

### 🧪 Testing
- Updated existing tests to use `PlaceOrderRequestV1` and `PlaceOrderResponseV1`
- Added integration test: `shouldAllowToPlaceAnOrderWhenLineItemsAreProvided()` verifying:
  - V2 endpoint accepts line items
  - Amount is computed from line items
  - Line items are returned in response
- All existing tests pass (backward compatibility verified)

### 📊 Observability
- Added version tags to `@Observed` annotations for metrics tracking
- V1: `{"version", "1.0.0"}`
- V2: `{"version", "2.0.0"}`

## Technical Details

### Amount Computation
- **V1**: Uses provided `amount` directly
- **V2**: Computes `amount` from line items (`sum(unitPrice * quantity)`) if not provided
- Validation ensures computed total matches provided amount (if provided)

### Validation
- Line item validation in `LineItem` record constructor
- Order-level validation in `OrderAggregate` constructor
- Request validation via Jakarta Bean Validation annotations

### Backward Compatibility
- ✅ V1 clients: No changes required, continue using `version=1.0.0` header
- ✅ V1 orders: Created with empty `lineItems` list
- ✅ V2 orders: Created with provided line items, amount computed if not provided

## Migration Notes

### For API Clients

**V1 Clients (No Changes Required)**
```http
POST /orders
Headers: version=1.0.0
Body: { "currency": "USD", "amount": 1000 }
```

**V2 Clients (New)**
```http
POST /orders
Body: {
  "currency": "USD",
  "lineItems": [
    { "name": "Product A", "quantity": 2, "unitPrice": 500, "reference": "SKU-001" },
    { "name": "Product B", "quantity": 1, "unitPrice": 1000, "reference": "SKU-002" }
  ]
}
```

**Default Behavior**: Requests without `version` header default to V2

### Database Migration
- Migration runs automatically on application startup (Flyway)
- No manual intervention required
- Existing orders remain unchanged (line items will be empty for V1 orders)

## Files Changed

### Domain Layer
- `src/main/java/com/ead/payments/orders/LineItem.java` (new)
- `src/main/java/com/ead/payments/orders/Order.java` (updated)
- `src/main/java/com/ead/payments/orders/OrderAggregate.java` (updated)
- `src/main/java/com/ead/payments/orders/OrderLineItemEntity.java` (new)
- `src/main/java/com/ead/payments/orders/OrderPlacedEvent.java` (updated)

### API Layer
- `src/main/java/com/ead/payments/orders/place/request/PlaceOrderRequestV1.java` (renamed)
- `src/main/java/com/ead/payments/orders/place/request/PlaceOrderRequestV2.java` (new)
- `src/main/java/com/ead/payments/orders/place/request/LineItemRequest.java` (new)
- `src/main/java/com/ead/payments/orders/place/response/PlaceOrderResponseV1.java` (new)
- `src/main/java/com/ead/payments/orders/place/response/PlaceOrderResponseV2.java` (new)
- `src/main/java/com/ead/payments/orders/response/LineItemResponse.java` (new, shared)
- `src/main/java/com/ead/payments/orders/search/SearchOrderResponse.java` (updated)

### Mapping Layer
- `src/main/java/com/ead/payments/orders/place/mapping/LineItemMapper.java` (new)
- `src/main/java/com/ead/payments/orders/place/mapping/PlaceOrderCommandMapper.java` (updated)
- `src/main/java/com/ead/payments/orders/place/mapping/PlaceOrderResponseMapper.java` (new)
- `src/main/java/com/ead/payments/orders/mapping/LineItemResponseMapper.java` (new)
- `src/main/java/com/ead/payments/orders/mapping/OrderAggregateMapper.java` (updated)
- `src/main/java/com/ead/payments/orders/search/mapping/SearchOrderResponseMapper.java` (new)

### Controllers & Services
- `src/main/java/com/ead/payments/orders/place/PlaceOrderController.java` (updated)
- `src/main/java/com/ead/payments/orders/search/SearchOrderController.java` (updated)
- `src/main/java/com/ead/payments/orders/place/PlaceOrderCommand.java` (updated)
- `src/main/java/com/ead/payments/orders/search/SearchOrderService.java` (updated)

### Database
- `src/main/resources/db/migration/V20251115_1219__add_line_items.sql` (new)

### Tests
- `src/test/java/com/ead/payments/orders/place/PlaceOrdersControllerTest.java` (updated)
- Updated all test files to use new DTOs

## Testing

- ✅ All existing tests pass
- ✅ V1 backward compatibility verified
- ✅ V2 endpoint tested with line items
- ✅ Integration test verifies line items in response
- ✅ Database migration tested

## Related Documentation

- See `docs/OBJECT_TREE.md` for complete object relationship diagram
- See `PlanToIntroduceLineItems.md` for detailed design rationale
