### PR TITLE
Add Terraform deployment for local Kubernetes and documentation

### DIFF
--- a/docs/local-k8s-terraform.md
+++ b/docs/local-k8s-terraform.md
@@ -1,0 +1,100 @@
+# Local Kubernetes + Terraform Guide (Base Payments)
+
+This guide shows how to build the Base Payments service into a local Docker image and deploy it with Terraform to a local Kubernetes cluster. The Terraform configuration enforces **three replicas** and exposes the service through a **LoadBalancer** service.
+
+## About load balancers on local Kubernetes
+Kubernetes defines a `LoadBalancer` Service type, but **the actual load balancer is provided by your cluster environment**. Local clusters typically need an add-on or helper:
+
+- **Docker Desktop / Rancher Desktop**: includes a built-in load balancer implementation, so `LoadBalancer` services usually work out of the box.
+- **Minikube**: use `minikube tunnel` to provision a local load balancer IP.
+- **Kind**: install a local load balancer such as **MetalLB**, or use `kubectl port-forward` as a fallback.
+
+## Prerequisites (macOS)
+Install the required tools (Terraform, kubectl, Docker Desktop) and verify the cluster is reachable.
+
+```bash
+brew install terraform kubectl
+brew install --cask docker
+```
+
+Start Docker Desktop, enable Kubernetes, and confirm access:
+
+```bash
+kubectl cluster-info
+kubectl get nodes
+```
+
+## 1) Build the local Docker image
+From the repository root:
+
+```bash
+./gradlew bootBuildImage --imageName base-payments:local
+```
+
+If you are using **kind**, load the image into the cluster:
+
+```bash
+kind load docker-image base-payments:local
+```
+
+## 2) (Optional) Start dependencies
+The application expects Postgres/Kafka. If you want to run the full stack locally, start the provided Docker Compose stack:
+
+```bash
+docker compose up -d
+```
+
+## 3) Deploy with Terraform
+Terraform configuration lives in `terraform/local-k8s`.
+
+```bash
+cd terraform/local-k8s
+terraform init
+terraform apply
+```
+
+Terraform creates:
+
+- a `base-payments` namespace
+- a Deployment with **3 replicas**
+- a `LoadBalancer` Service (`base-payments-lb`)
+
+## 4) Verify the deployment
+
+```bash
+kubectl get pods -n base-payments
+kubectl get svc -n base-payments
+```
+
+If your local Kubernetes cluster needs help exposing LoadBalancer IPs:
+
+- **Minikube**: run `minikube tunnel` in another terminal.
+- **Kind**: install MetalLB, or run a temporary port forward:
+
+```bash
+kubectl port-forward -n base-payments svc/base-payments-lb 8080:80
+```
+
+## 5) Test the service
+Once the service has an external IP (or after port-forwarding):
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+## 6) Tear down
+
+```bash
+terraform destroy
+```
+
+## Customization
+You can override defaults with Terraform variables:
+
+```bash
+terraform apply \
+  -var="image=base-payments:local" \
+  -var="replicas=3" \
+  -var="container_port=8080" \
+  -var="service_port=80"
+```

--- a/terraform/local-k8s/main.tf
+++ b/terraform/local-k8s/main.tf
@@ -1,0 +1,115 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig_path
+}
+
+locals {
+  app_labels = {
+    app = var.app_name
+  }
+}
+
+resource "kubernetes_namespace" "app" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "kubernetes_deployment" "app" {
+  metadata {
+    name      = var.app_name
+    namespace = kubernetes_namespace.app.metadata[0].name
+    labels    = local.app_labels
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = local.app_labels
+    }
+
+    template {
+      metadata {
+        labels = local.app_labels
+      }
+
+      spec {
+        container {
+          name              = var.app_name
+          image             = var.image
+          image_pull_policy = "IfNotPresent"
+
+          port {
+            container_port = var.container_port
+          }
+
+          env {
+            name  = "SERVER_PORT"
+            value = tostring(var.container_port)
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/actuator/health/readiness"
+              port = var.container_port
+            }
+
+            initial_delay_seconds = 20
+            period_seconds        = 10
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/actuator/health/liveness"
+              port = var.container_port
+            }
+
+            initial_delay_seconds = 30
+            period_seconds        = 20
+          }
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "512Mi"
+            }
+
+            limits = {
+              cpu    = "500m"
+              memory = "1Gi"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "app" {
+  metadata {
+    name      = "${var.app_name}-lb"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+
+  spec {
+    selector = local.app_labels
+
+    port {
+      port        = var.service_port
+      target_port = var.container_port
+    }
+
+    type = "LoadBalancer"
+  }
+}

--- a/terraform/local-k8s/outputs.tf
+++ b/terraform/local-k8s/outputs.tf
@@ -1,0 +1,9 @@
+output "service_name" {
+  description = "Name of the Kubernetes Service created for the app."
+  value       = kubernetes_service.app.metadata[0].name
+}
+
+output "namespace" {
+  description = "Namespace where the resources were deployed."
+  value       = kubernetes_namespace.app.metadata[0].name
+}

--- a/terraform/local-k8s/variables.tf
+++ b/terraform/local-k8s/variables.tf
@@ -1,0 +1,41 @@
+variable "kubeconfig_path" {
+  description = "Path to the kubeconfig file to use for the Kubernetes provider."
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "namespace" {
+  description = "Namespace for the Base Payments deployment."
+  type        = string
+  default     = "base-payments"
+}
+
+variable "app_name" {
+  description = "Name for the application resources."
+  type        = string
+  default     = "base-payments"
+}
+
+variable "image" {
+  description = "Container image to run. Use a local Docker image name for local clusters."
+  type        = string
+  default     = "base-payments:local"
+}
+
+variable "replicas" {
+  description = "Number of application replicas to run."
+  type        = number
+  default     = 3
+}
+
+variable "container_port" {
+  description = "Container port exposed by the Spring Boot application."
+  type        = number
+  default     = 8080
+}
+
+variable "service_port" {
+  description = "Service port for external access."
+  type        = number
+  default     = 80
+}


### PR DESCRIPTION
### Motivation
- Provide a simple Terraform configuration to deploy the Base Payments service to a local Kubernetes cluster with a guaranteed number of replicas and external access.
- Ensure the application runs as three instances behind a Kubernetes Service of type `LoadBalancer` for local integration testing.
- Clarify how local Kubernetes environments provide `LoadBalancer` functionality and offer fallbacks for clusters without a built-in load balancer.
- Update the local image build instruction to use the Spring Boot image builder for consistent local image creation.

### Description
- Added `terraform/local-k8s/main.tf` which provisions a `base-payments` namespace, a `Deployment` (with `replicas = var.replicas`) and a `LoadBalancer` `Service`, plus readiness/liveness probes and resource requests/limits.
- Added `terraform/local-k8s/variables.tf` declaring configurable variables such as `kubeconfig_path`, `image`, `replicas`, `container_port`, and `service_port` with reasonable defaults.
- Added `terraform/local-k8s/outputs.tf` exposing the created `service_name` and `namespace` as Terraform outputs.
- Added `docs/local-k8s-terraform.md` with macOS terminal commands and a step-by-step guide using `./gradlew bootBuildImage --imageName base-payments:local`, `terraform init`, `terraform apply`, and recommended cluster-specific steps (e.g., `kind load docker-image`, `minikube tunnel`, or `kubectl port-forward`).

### Testing
- No automated tests were executed for these infrastructure and documentation changes.
- The Terraform configuration was created but `terraform init` / `terraform apply` were not run during this change.
- Documentation command examples (e.g., `./gradlew bootBuildImage --imageName base-payments:local` and `terraform apply`) are provided but were not validated by automated runs.
- Manual verification steps are documented in `docs/local-k8s-terraform.md` for users to follow on their environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f935c048c83279364cfda07ae78fc)