### PR TITLE
CI: use minimal Docker Compose stack for tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Run Tests
         uses: gradle/gradle-build-action@v2
+        env:
+          SPRING_DOCKER_COMPOSE_FILE: docker-ci.yml
         with:
           arguments: test -Djava.compiler.args="--enable-preview" --parallel
 

--- a/docker-ci.yml
+++ b/docker-ci.yml
@@ -1,0 +1,49 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:latest
+    networks:
+      - integration-test
+    environment:
+      POSTGRES_DB: orders
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+    command: ["postgres", "-c", "max_connections=200"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d orders"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  kafka:
+    image: apache/kafka:3.7.1
+    networks:
+      - integration-test
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+    ports:
+      - "9092:9092"
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 40s
+
+networks:
+  integration-test:
+    driver: bridge

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -39,13 +39,12 @@
     <logger name="org.apache.juli.logging.DirectJDKLog" level="ERROR"/>
     <logger name="org.springframework.jdbc.core.JdbcTemplate" level="INFO"/>
 
-    <springProfile name="local">
+    <springProfile name="integration-test">
         <root level="INFO">
             <appender-ref ref="Console"/>
-            <appender-ref ref="Loki"/>
         </root>
     </springProfile>
-    <springProfile name="!local">
+    <springProfile name="!integration-test">
         <root level="INFO">
             <appender-ref ref="Console"/>
             <appender-ref ref="Loki"/>


### PR DESCRIPTION
## Summary
- add `docker-ci.yml` with only core test dependencies (PostgreSQL + Kafka)
- configure GitHub Actions test job to use `SPRING_DOCKER_COMPOSE_FILE=docker-ci.yml`
- keep local `compose.yaml` unchanged for full observability stack usage

## Validation
- SPRING_DOCKER_COMPOSE_FILE=docker-ci.yml ./gradlew clean test --no-daemon --stacktrace