### PR TITLE
[codex] Bump minimal dependency patch set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'idea'
 	id 'jacoco'
 
-	id 'org.springframework.boot' version '4.0.2'
+	id 'org.springframework.boot' version '4.0.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -34,7 +34,7 @@ repositories {
 }
 
 ext {
-	set('springModulithVersion', "2.0.2")
+	set('springModulithVersion', "2.0.3")
 	set('springCloudVersion', "2025.1.1")
 }
 
@@ -65,7 +65,7 @@ dependencies {
 
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 
 	runtimeOnly 'org.postgresql:postgresql'
 


### PR DESCRIPTION
## What changed
- bump Spring Boot from `4.0.2` to `4.0.3`
- bump Spring Modulith BOM from `2.0.2` to `2.0.3`
- bump `springdoc-openapi-starter-webmvc-ui` from `3.0.1` to `3.0.2`

## Why
These are the smallest patch-level dependency upgrades identified in the repo that should improve currency with minimal migration risk.

## Impact
- no application code changes
- managed Spring dependencies refresh through the Spring Boot patch bump
- avoids larger-risk upgrades such as Guava, Loki4j, and MapStruct in this pass

## Validation
- `./gradlew test` started and compilation succeeded
- full test execution is blocked in this environment because Spring Boot Docker Compose support fails with `Docker is not running`
