### PR TITLE
[codex] Update Spring and local stack dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'idea'
 	id 'jacoco'
 
-	id 'org.springframework.boot' version '4.0.3'
+	id 'org.springframework.boot' version '4.0.6'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -34,8 +34,10 @@ repositories {
 }
 
 ext {
-	set('springModulithVersion', "2.0.3")
+	set('springModulithVersion', "2.0.6")
 	set('springCloudVersion', "2025.1.1")
+	set('flyway.version', "12.6.2")
+	set('opentelemetry.version', "1.62.0")
 }
 
 dependencies {
@@ -58,7 +60,7 @@ dependencies {
 	implementation 'org.springframework.modulith:spring-modulith-starter-jpa'
 
 	implementation 'org.springframework.boot:spring-boot-starter-flyway'
-	implementation 'org.flywaydb:flyway-database-postgresql'
+	implementation 'org.flywaydb:flyway-database-postgresql:12.6.2'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -66,33 +68,33 @@ dependencies {
 
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 
-	runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'org.postgresql:postgresql:42.7.11'
 
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	// Spring Boot 4.0.2 manages OpenTelemetry 1.55.0, so we pin the matching appender line.
-	implementation 'io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.21.0-alpha'
+	// Keep the logback appender aligned with its OpenTelemetry API line.
+	implementation 'io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.28.1-alpha'
 
-	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
-	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+	implementation 'org.mapstruct:mapstruct:1.6.3'
 
-	testImplementation 'org.wiremock.integrations:wiremock-spring-boot:4.1.0'
+	testImplementation 'org.wiremock.integrations:wiremock-spring-boot:4.2.1'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation 'org.springframework.boot:spring-boot-docker-compose'
 	testImplementation 'org.springframework.modulith:spring-modulith-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 
-	testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.1'
-	testImplementation 'com.tngtech.archunit:archunit-junit5-api:1.4.1'
-	testImplementation 'com.tngtech.archunit:archunit:1.4.1'
+	testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.2'
+	testImplementation 'com.tngtech.archunit:archunit-junit5-api:1.4.2'
+	testImplementation 'com.tngtech.archunit:archunit:1.4.2'
 
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
-	implementation 'com.google.guava:guava:33.2.1-jre'
-	implementation 'org.apache.commons:commons-collections4:4.4'
-	implementation 'org.apache.commons:commons-lang3:3.19.0'
+	implementation 'com.google.guava:guava:33.6.0-jre'
+	implementation 'org.apache.commons:commons-collections4:4.5.0'
+	implementation 'org.apache.commons:commons-lang3:3.20.0'
 
 }
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
   postgres:
     container_name: postgres
-    image: postgres:latest
+    image: postgres:18.4
     networks:
       - integration-test
     volumes:
@@ -22,7 +22,7 @@ services:
 
   pgadmin:
     container_name: pgadmin4
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:9.15.0
     restart: always
     networks:
       - integration-test
@@ -41,7 +41,7 @@ services:
       retries: 3
 
   kafka:
-    image: apache/kafka:3.7.1
+    image: apache/kafka:4.3.0
     container_name: kafka
     networks:
       - integration-test
@@ -71,7 +71,7 @@ services:
       start_period: 120s
 
   akhq:
-    image: tchiotludo/akhq:latest
+    image: tchiotludo/akhq:0.27.1
     container_name: akhq
     networks:
       - integration-test
@@ -90,7 +90,7 @@ services:
 
   wiremock:
     # Official WireMock image with native arm64 support for Apple Silicon.
-    image: wiremock/wiremock:3.13.2-2
+    image: wiremock/wiremock:3.13.2-3
     container_name: issuer-wiremock
     networks:
       - integration-test
@@ -102,7 +102,7 @@ services:
 
   observability:
     # Single local LGTM stack with native OTLP ingest for logs, metrics and traces.
-    image: grafana/otel-lgtm:0.24.0
+    image: grafana/otel-lgtm:0.28.0
     container_name: observability
     networks:
       - integration-test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- Update Spring Boot, Spring Modulith, Flyway, OpenTelemetry, Gradle, and direct JVM dependencies.
- Pin and update local Docker Compose images for Postgres, Kafka, pgAdmin, AKHQ, WireMock, and Grafana OTEL LGTM.
- Keep Spring Cloud on the current 2025.1.1 line.

## Validation

- `docker compose config --quiet`
- `docker compose up -d postgres kafka`
- `./gradlew test`

The integration test run validated Postgres 18.4 and Kafka 4.3.0 with the updated dependency set.