### PR TITLE
Add paginated order management endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,15 @@ Each shipped entry should include:
 Application version: `0.0.1-SNAPSHOT`
 
 ### Added
+- Added `GET /orders` with deterministic pagination and optional lifecycle and creation-period filters.
 - Added idempotent order completion with `PUT /orders/{order_id}/complete`.
 - Added `OrderCompletedEvent` for first-time `PLACED -> COMPLETED` transitions.
 - Added specific terminal-state exceptions for completing cancelled orders and cancelling completed orders.
 - Added semantic API-version validation for the existing `version` header, with V2 as the default and unsupported versions rejected early.
 
 ### Changed
+- Made order event-history reads return only persisted publications, with truthful empty collections and event-specific `404` responses.
+- Added creation timestamps to order-listing responses and batched line-item loading for paginated reads.
 - Upgraded Spring Boot from 4.0.6 to 4.1.0, Spring Modulith from 2.0.6 to 2.1.0, and Spring Cloud from 2025.1.1 to 2025.1.2.
 - Replaced the manually assembled issuer HTTP proxy with Spring Boot's named service-client group, including managed timeouts, redirects, JSON conversion, and correlation-header forwarding.
 - Made unchanged V1 HTTP contracts compatible with supported V2/default requests through baseline version mappings.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Spring parses the existing `version` header as a semantic API version. Versions 
 | --- | --- | --- | --- |
 | `POST` | `/orders` | Header `version: 1.0.0` creates a V1 order and returns `version`/`status` | `CUSTOMER` or `MERCHANT` |
 | `POST` | `/orders` | Header `version: 2.0.0`, or no version header, creates a V2 line-item order | `CUSTOMER` or `MERCHANT` |
+| `GET` | `/orders` | V1-compatible paginated listing; filters by `status`, `created_from`, and `created_to` | `CUSTOMER` or `MERCHANT` |
 | `GET` | `/orders/{order_id}` | V1-compatible; accepts `1.0.0`, `2.0.0`, or the default | `CUSTOMER` or `MERCHANT` |
 | `POST` | `/orders/{order_id}/cancel` | V1-compatible; accepts `1.0.0`, `2.0.0`, or the default | `CUSTOMER` or `MERCHANT` |
 | `PUT` | `/orders/{order_id}/complete` | V1-compatible and idempotent for already completed orders | `CUSTOMER` or `MERCHANT` |
@@ -174,6 +175,20 @@ curl --request POST 'http://localhost:8080/orders' \
 ```
 
 JSON uses `snake_case` globally.
+
+Example order listing request:
+
+```bash
+curl --get 'http://localhost:8080/orders' \
+  --user merchant:password \
+  --data-urlencode 'status=PLACED' \
+  --data-urlencode 'created_from=2026-07-01T00:00:00Z' \
+  --data-urlencode 'created_to=2026-07-31T23:59:59Z' \
+  --data-urlencode 'page=0' \
+  --data-urlencode 'size=20'
+```
+
+The collection is ordered by newest creation time and then by order id. `page` starts at `0`, and `size` accepts values from `1` through `100`. An inverted creation period returns `400 Bad Request`. Event history endpoints return only persisted event publications: an empty history is `200 []`, while a missing specific event is `404 Not Found`.
 
 ## Architecture At A Glance
 

--- a/docs/agents/MEMORIES.md
+++ b/docs/agents/MEMORIES.md
@@ -48,7 +48,7 @@ Do not use this as a substitute for reading the repo. Use it as a compass.
 
 - Older documentation used to conflict with Gradle by mentioning Java 24 and Spring Boot 3.x/4.0.x. The agent docs should now point back to Java 25 and Spring Boot 4.1.0.
 - The worktree may include a user-driven Jackson package move from `json` to `configurations`. Do not revert it.
-- `EventsController` currently has hardcoded fallback event responses when stored events are missing. Treat this as a known rough edge.
+- Event-history endpoints return only persisted publications. Empty histories are truthful empty collections, and missing specific events return `404`.
 - The worktree may contain generated/local artifacts such as `.gradle-user-home/`, `BOOT-INF/`, `META-INF/`, `.DS_Store`, and `terraform/`.
 
 ## Handoff Notes Template
@@ -106,3 +106,9 @@ YYYY-MM-DD - Agent note:
 - Why it matters: The project now uses the supported 4.1 platform and demonstrates the modern client/versioning capabilities expected of this case study.
 - Verification: Production and existing test-source compilation plus the existing architecture and logging tests passed. Full integration tests still require Docker.
 - Follow-up: Preserve `version` as the public header, keep V2 as the default, and avoid test changes unless the user explicitly requests them.
+
+2026-07-22 - Read-only order management expansion:
+- What changed: Added paginated order listing with status and creation-period filters, and removed fabricated event-history fallbacks.
+- Why it matters: Financial order history remains auditable, while operators can browse orders without introducing generic mutation or physical deletion.
+- Verification: Production/test compilation, focused integration tests, and architecture tests were run in the feature worktree.
+- Follow-up: Keep future order state changes as explicit domain actions rather than generic `PUT`, `PATCH`, or `DELETE` operations.

--- a/docs/agents/MODULE_INTERACTIONS.md
+++ b/docs/agents/MODULE_INTERACTIONS.md
@@ -120,10 +120,24 @@ EventsController
   -> OrderEventService
     -> OrderEventRepository
       -> event publication table
-  -> OrderEventResponse
+  -> persisted OrderEventResponse, empty collection, or event-specific 404
 ```
 
-Candid note: `EventsController` currently returns hardcoded fallback event responses if the service returns no stored event. Treat this as a rough edge and avoid copying the pattern into new production-shaped endpoints.
+Event reads query persisted publications by the serialized event's order id. The collection endpoint returns an empty list when no publications match; the event-specific endpoint returns `404` when the requested publication does not exist for that order.
+
+## Order Listing Flow
+
+```text
+OrderListingController
+  -> validates page, size, status, and ISO-8601 creation bounds
+  -> OrderListingService
+    -> rejects inverted creation periods
+    -> builds only the requested JPA specifications
+    -> OrderRepository returns a deterministic page
+  -> OrderListingResponse with content and page metadata
+```
+
+Listing is read-only. State changes remain explicit domain actions such as cancel and complete; the API does not expose generic update or physical-delete operations for financial orders.
 
 ## Module Contract Table
 
@@ -133,6 +147,7 @@ Candid note: `EventsController` currently returns hardcoded fallback event respo
 | `orders.place` | Place-order use case, issuer gateway/client | `OrderRepository`, `IssuerGateway` | Order aggregate events through save |
 | `orders.cancel` | Cancel-order use case | `OrderRepository` | `OrderCancelledEvent` through aggregate |
 | `orders.complete` | Complete-order use case | `OrderRepository` | `OrderCompletedEvent` through aggregate |
+| `orders.list` | Paginated order browsing and filters | `OrderRepository` | None |
 | `orders.search` | Order lookup | `OrderRepository` | None |
 | `orders.events` | Event read API | Modulith/event publication persistence | None |
 | `products` | Product aggregate and create-product use case | `ProductRepository` | `ProductCreatedEvent` |

--- a/docs/agents/PROJECT_ATLAS.md
+++ b/docs/agents/PROJECT_ATLAS.md
@@ -66,6 +66,7 @@ Business modules:
 - `orders.place`: place-order HTTP flow, request versions, issuer authorization, command and response mapping.
 - `orders.cancel`: cancel-order use case.
 - `orders.complete`: complete-order use case with idempotent completion semantics.
+- `orders.list`: paginated order browsing with lifecycle and creation-period filters.
 - `orders.search`: search-order use case.
 - `orders.events`: read access over stored order events.
 - `products`: product aggregate and create-product use case.
@@ -110,7 +111,7 @@ Current controllers expose:
 
 - `POST /orders` with `version: 1.0.0` for V1 orders; returns order `version` and lifecycle `status`.
 - `POST /orders` with `version: 2.0.0`, or without a version header, for V2 line-item orders; returns order `version` and lifecycle `status`.
-- `GET /orders/{order_id}`, cancel, complete, event-read, and product-create contracts are compatible from `1.0.0` onward. They accept either supported version, and no header selects `2.0.0`.
+- `GET /orders`, `GET /orders/{order_id}`, cancel, complete, event-read, and product-create contracts are compatible from `1.0.0` onward. They accept either supported version, and no header selects `2.0.0`.
 - Versions other than `1.0.0` and `2.0.0` are rejected with `400 Bad Request` before a controller runs.
 
 JSON is `snake_case`.
@@ -119,5 +120,5 @@ JSON is `snake_case`.
 
 - Older docs used to mention Java 24 and Spring Boot 3.x/4.0.x. `build.gradle` says Java 25 and Spring Boot 4.1.0.
 - The worktree may include a user package move from `com.ead.payments.json` to `com.ead.payments.configurations`. Do not revert it.
-- `EventsController` has a hardcoded fallback response when stored events are missing. That is useful to know before treating event reads as fully production-shaped.
+- Order event reads are backed only by persisted Modulith publications; the API does not fabricate fallback events.
 - Some generated/local directories may be present in the worktree. Ignore unrelated artifacts unless the task explicitly targets them.

--- a/src/main/java/com/ead/payments/orders/OrderAggregate.java
+++ b/src/main/java/com/ead/payments/orders/OrderAggregate.java
@@ -16,10 +16,12 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.data.domain.AbstractAggregateRoot;
 import org.springframework.data.domain.Persistable;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.security.authorization.method.AuthorizeReturnObject;
 
 import java.util.ArrayList;
 import java.util.Currency;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -43,6 +45,9 @@ public class OrderAggregate extends AbstractAggregateRoot<OrderAggregate> implem
     @Version
     private Long version;
 
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Instant createdAt;
+
     @Column
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
@@ -55,6 +60,7 @@ public class OrderAggregate extends AbstractAggregateRoot<OrderAggregate> implem
     private Long amount;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
     private List<OrderLineItemEntity> lineItems = new ArrayList<>();
 
     public OrderAggregate(PlaceOrderCommand command) {

--- a/src/main/java/com/ead/payments/orders/OrderControlAdvice.java
+++ b/src/main/java/com/ead/payments/orders/OrderControlAdvice.java
@@ -2,6 +2,8 @@ package com.ead.payments.orders;
 
 import com.ead.payments.orders.cancel.CompletedOrderCancellationException;
 import com.ead.payments.orders.complete.CancelledOrderCompletionException;
+import com.ead.payments.orders.events.OrderEventNotFoundException;
+import com.ead.payments.orders.list.InvalidOrderListingPeriodException;
 import java.net.URI;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -42,6 +44,30 @@ public class OrderControlAdvice {
         problemDetail.setType(URI.create("v1/orders"));
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
+                .body(problemDetail);
+    }
+
+    @ExceptionHandler(OrderEventNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleOrderEventNotFoundException(OrderEventNotFoundException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        problemDetail.setTitle("Order Event Not Found");
+        problemDetail.setDetail(ex.getMessage());
+        problemDetail.setType(URI.create("v1/orders/events"));
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(problemDetail);
+    }
+
+    @ExceptionHandler(InvalidOrderListingPeriodException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidOrderListingPeriodException(
+            InvalidOrderListingPeriodException ex
+    ) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        problemDetail.setTitle("Invalid Order Listing Period");
+        problemDetail.setDetail(ex.getMessage());
+        problemDetail.setType(URI.create("v1/orders"));
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
                 .body(problemDetail);
     }
 

--- a/src/main/java/com/ead/payments/orders/OrderRepository.java
+++ b/src/main/java/com/ead/payments/orders/OrderRepository.java
@@ -2,9 +2,10 @@ package com.ead.payments.orders;
 
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface OrderRepository extends JpaRepository<OrderAggregate, UUID> {
-
+public interface OrderRepository extends JpaRepository<OrderAggregate, UUID>,
+        JpaSpecificationExecutor<OrderAggregate> {
 }

--- a/src/main/java/com/ead/payments/orders/events/EventsController.java
+++ b/src/main/java/com/ead/payments/orders/events/EventsController.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -36,22 +35,8 @@ public class EventsController {
         try (OrderIdLoggingContext.Scope ignored = OrderIdLoggingContext.withOrderId(orderId)) {
             log.info("Retrieving events for order: {}", orderId);
 
-            // Try to get events from the service
             List<OrderEventResponse> events = orderEventService.findAllByOrderId(orderId);
             log.info("Found {} events from service", events.size());
-
-            // If no events found, return a hardcoded response for testing
-            if (events.isEmpty()) {
-                log.info("Returning hardcoded event for testing");
-                UUID eventId = UUID.randomUUID();
-                return List.of(new OrderEventResponse(
-                        eventId,
-                        java.time.Instant.now(),
-                        "OrderPlacedEvent",
-                        "{\"orderId\":\"" + orderId + "\",\"status\":\"PLACED\"}"
-                ));
-            }
-
             return events;
         }
     }
@@ -61,31 +46,18 @@ public class EventsController {
      *
      * @param orderId the ID of the order
      * @param eventId the ID of the event
-     * @return the event, or empty if not found
+     * @return the event
      */
     @GetMapping(path = "/{order_id}/events/{event_id}", version = "1.0.0+")
     @ResponseStatus(HttpStatus.OK)
-    public Optional<OrderEventResponse> getOrderEvent(
+    public OrderEventResponse getOrderEvent(
             @PathVariable("order_id") @NotNull UUID orderId,
             @PathVariable("event_id") @NotNull UUID eventId) {
         try (OrderIdLoggingContext.Scope ignored = OrderIdLoggingContext.withOrderId(orderId)) {
             log.info("Retrieving event {} for order: {}", eventId, orderId);
 
-            // Try to get the event from the service
-            Optional<OrderEventResponse> event = orderEventService.findByOrderIdAndEventId(orderId, eventId);
-
-            // If no event found, return a hardcoded response for testing
-            if (event.isEmpty()) {
-                log.info("Returning hardcoded event for testing");
-                return Optional.of(new OrderEventResponse(
-                        eventId,
-                        java.time.Instant.now(),
-                        "OrderPlacedEvent",
-                        "{\"orderId\":\"" + orderId + "\",\"status\":\"PLACED\"}"
-                ));
-            }
-
-            return event;
+            return orderEventService.findByOrderIdAndEventId(orderId, eventId)
+                    .orElseThrow(() -> new OrderEventNotFoundException(orderId, eventId));
         }
     }
 }

--- a/src/main/java/com/ead/payments/orders/events/OrderEventNotFoundException.java
+++ b/src/main/java/com/ead/payments/orders/events/OrderEventNotFoundException.java
@@ -1,0 +1,10 @@
+package com.ead.payments.orders.events;
+
+import java.util.UUID;
+
+public class OrderEventNotFoundException extends RuntimeException {
+
+    public OrderEventNotFoundException(UUID orderId, UUID eventId) {
+        super("Event %s was not found for order %s".formatted(eventId, orderId));
+    }
+}

--- a/src/main/java/com/ead/payments/orders/events/OrderEventRepository.java
+++ b/src/main/java/com/ead/payments/orders/events/OrderEventRepository.java
@@ -16,20 +16,17 @@ import java.util.UUID;
 public interface OrderEventRepository extends JpaRepository<OrderEvent, UUID> {
 
     /**
-     * Find all events.
-     *
-     * @return a list of all events
-     */
-    @Query(value = "SELECT * FROM orders.event_publication", nativeQuery = true)
-    List<OrderEvent> findAllEvents();
-
-    /**
      * Find all events for an order.
      *
      * @param orderId the ID of the order
      * @return a list of events for the order
      */
-    @Query(value = "SELECT * FROM orders.event_publication WHERE serialized_event LIKE CONCAT('%', :orderId, '%')", nativeQuery = true)
+    @Query(value = """
+            SELECT *
+            FROM orders.event_publication
+            WHERE serialized_event::jsonb ->> 'id' = :orderId
+            ORDER BY publication_date ASC, id ASC
+            """, nativeQuery = true)
     List<OrderEvent> findByOrderId(@Param("orderId") String orderId);
 
     /**
@@ -39,6 +36,11 @@ public interface OrderEventRepository extends JpaRepository<OrderEvent, UUID> {
      * @param eventId the ID of the event
      * @return the event, or empty if not found
      */
-    @Query(value = "SELECT * FROM orders.event_publication WHERE serialized_event LIKE CONCAT('%', :orderId, '%') AND id = :eventId", nativeQuery = true)
+    @Query(value = """
+            SELECT *
+            FROM orders.event_publication
+            WHERE serialized_event::jsonb ->> 'id' = :orderId
+              AND id = :eventId
+            """, nativeQuery = true)
     Optional<OrderEvent> findByOrderIdAndEventId(@Param("orderId") String orderId, @Param("eventId") UUID eventId);
 }

--- a/src/main/java/com/ead/payments/orders/events/OrderEventService.java
+++ b/src/main/java/com/ead/payments/orders/events/OrderEventService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * Service for retrieving order events from the event_publication table.
@@ -28,21 +27,12 @@ public class OrderEventService {
     public List<OrderEventResponse> findAllByOrderId(UUID orderId) {
         log.info("Finding all events for order: {}", orderId);
 
-        // First, try to find all events to see if any exist
-        List<OrderEvent> allEvents = orderEventRepository.findAllEvents();
-        log.info("Found {} events in total", allEvents.size());
-        for (OrderEvent event : allEvents) {
-            log.info("Event: id={}, type={}, serializedEvent={}", 
-                    event.getId(), event.getEventType(), event.getSerializedEvent());
-        }
-
-        // Then, try to find events for the specific order
         List<OrderEvent> orderEvents = orderEventRepository.findByOrderId(orderId.toString());
         log.info("Found {} events for order {}", orderEvents.size(), orderId);
 
         return orderEvents.stream()
                 .map(this::mapToResponse)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/src/main/java/com/ead/payments/orders/list/InvalidOrderListingPeriodException.java
+++ b/src/main/java/com/ead/payments/orders/list/InvalidOrderListingPeriodException.java
@@ -1,0 +1,11 @@
+package com.ead.payments.orders.list;
+
+import java.time.Instant;
+
+public class InvalidOrderListingPeriodException extends IllegalArgumentException {
+
+    public InvalidOrderListingPeriodException(Instant createdFrom, Instant createdTo) {
+        super("Order listing start must not be after its end: %s > %s"
+                .formatted(createdFrom, createdTo));
+    }
+}

--- a/src/main/java/com/ead/payments/orders/list/OrderListingController.java
+++ b/src/main/java/com/ead/payments/orders/list/OrderListingController.java
@@ -1,0 +1,40 @@
+package com.ead.payments.orders.list;
+
+import com.ead.payments.orders.Order.OrderStatus;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(path = "/orders")
+@RolesAllowed({"ROLE_MERCHANT", "ROLE_CUSTOMER"})
+public class OrderListingController {
+
+    private final OrderListingService orderListingService;
+
+    @GetMapping(version = "1.0.0+")
+    @ResponseStatus(HttpStatus.OK)
+    public OrderListingResponse listOrders(
+            @RequestParam(required = false) OrderStatus status,
+            @RequestParam(name = "created_from", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant createdFrom,
+            @RequestParam(name = "created_to", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant createdTo,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        return orderListingService.findAll(status, createdFrom, createdTo, page, size);
+    }
+}

--- a/src/main/java/com/ead/payments/orders/list/OrderListingItemResponse.java
+++ b/src/main/java/com/ead/payments/orders/list/OrderListingItemResponse.java
@@ -1,0 +1,19 @@
+package com.ead.payments.orders.list;
+
+import com.ead.payments.orders.Order.OrderStatus;
+import com.ead.payments.orders.response.LineItemResponse;
+import java.time.Instant;
+import java.util.Currency;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderListingItemResponse(
+        UUID id,
+        Long version,
+        Instant createdAt,
+        OrderStatus status,
+        Currency currency,
+        Long amount,
+        List<LineItemResponse> lineItems
+) {
+}

--- a/src/main/java/com/ead/payments/orders/list/OrderListingResponse.java
+++ b/src/main/java/com/ead/payments/orders/list/OrderListingResponse.java
@@ -1,0 +1,12 @@
+package com.ead.payments.orders.list;
+
+import java.util.List;
+
+public record OrderListingResponse(
+        List<OrderListingItemResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/ead/payments/orders/list/OrderListingService.java
+++ b/src/main/java/com/ead/payments/orders/list/OrderListingService.java
@@ -1,0 +1,82 @@
+package com.ead.payments.orders.list;
+
+import com.ead.payments.orders.Order.OrderStatus;
+import com.ead.payments.orders.OrderAggregate;
+import com.ead.payments.orders.OrderAggregateMapper;
+import com.ead.payments.orders.OrderRepository;
+import com.ead.payments.orders.mapping.LineItemResponseMapper;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderListingService {
+
+    private final OrderRepository orderRepository;
+    private final OrderAggregateMapper orderAggregateMapper;
+    private final LineItemResponseMapper lineItemResponseMapper;
+
+    @Transactional(readOnly = true)
+    public OrderListingResponse findAll(
+            OrderStatus status,
+            Instant createdFrom,
+            Instant createdTo,
+            int page,
+            int size
+    ) {
+        if (createdFrom != null && createdTo != null && createdFrom.isAfter(createdTo)) {
+            throw new InvalidOrderListingPeriodException(createdFrom, createdTo);
+        }
+
+        var pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Order.desc("createdAt"), Sort.Order.desc("id"))
+        );
+        Specification<OrderAggregate> specification = (root, query, criteriaBuilder) ->
+                criteriaBuilder.conjunction();
+        if (status != null) {
+            specification = specification.and((root, query, criteriaBuilder) ->
+                    criteriaBuilder.equal(root.get("status"), status));
+        }
+        if (createdFrom != null) {
+            specification = specification.and((root, query, criteriaBuilder) ->
+                    criteriaBuilder.greaterThanOrEqualTo(root.get("createdAt"), createdFrom));
+        }
+        if (createdTo != null) {
+            specification = specification.and((root, query, criteriaBuilder) ->
+                    criteriaBuilder.lessThanOrEqualTo(root.get("createdAt"), createdTo));
+        }
+
+        var orders = orderRepository.findAll(specification, pageable);
+        var content = orders.getContent().stream()
+                .map(this::toResponse)
+                .toList();
+
+        return new OrderListingResponse(
+                content,
+                orders.getNumber(),
+                orders.getSize(),
+                orders.getTotalElements(),
+                orders.getTotalPages()
+        );
+    }
+
+    private OrderListingItemResponse toResponse(OrderAggregate aggregate) {
+        var order = orderAggregateMapper.toOrder(aggregate);
+        return new OrderListingItemResponse(
+                aggregate.getId(),
+                aggregate.getVersion(),
+                aggregate.getCreatedAt(),
+                aggregate.getStatus(),
+                aggregate.getCurrency(),
+                aggregate.getAmount(),
+                lineItemResponseMapper.from(order.lineItems())
+        );
+    }
+}

--- a/src/test/java/com/ead/payments/orders/events/EventsControllerTest.java
+++ b/src/test/java/com/ead/payments/orders/events/EventsControllerTest.java
@@ -15,9 +15,11 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Currency;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -118,5 +120,36 @@ class EventsControllerTest extends SpringBootIntegrationTest {
                 .andExpect(jsonPath("$.id", is(eventId)))
                 .andExpect(jsonPath("$.event_type", is(notNullValue())))
                 .andExpect(jsonPath("$.event_data", is(notNullValue())));
+    }
+
+    @Test
+    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @DisplayName("Should return an empty history when an order has no stored events")
+    void shouldReturnAnEmptyHistoryWhenAnOrderHasNoStoredEvents() throws Exception {
+        // given: an order identifier with no stored event publications
+        var orderId = UUID.randomUUID();
+
+        // when: the customer reads that order history
+        var response = mockMvc.perform(get("/orders/" + orderId + "/events"));
+
+        // then: the API returns the truthful empty collection
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @DisplayName("Should report a missing event when it is absent from an order history")
+    void shouldReportAMissingEventWhenItIsAbsentFromAnOrderHistory() throws Exception {
+        // given: identifiers with no matching stored event publication
+        var orderId = UUID.randomUUID();
+        var eventId = UUID.randomUUID();
+
+        // when: the customer requests that specific event
+        var response = mockMvc.perform(get("/orders/" + orderId + "/events/" + eventId));
+
+        // then: the API reports that the event does not exist
+        response.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title", is("Order Event Not Found")));
     }
 }

--- a/src/test/java/com/ead/payments/orders/list/OrderListingControllerTest.java
+++ b/src/test/java/com/ead/payments/orders/list/OrderListingControllerTest.java
@@ -1,0 +1,88 @@
+package com.ead.payments.orders.list;
+
+import com.ead.payments.SpringBootIntegrationTest;
+import com.ead.payments.providers.OrderPlacedProvider;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OrderListingControllerTest extends SpringBootIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private OrderPlacedProvider orderPlacedProvider;
+
+    @Test
+    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @DisplayName("Should return a paginated collection when orders exist")
+    void shouldReturnAPaginatedCollectionWhenOrdersExist() throws Exception {
+        // given: an order has been placed by a customer
+        var placedOrder = orderPlacedProvider.placeOrder();
+
+        // when: the customer browses the first page of orders
+        var response = mockMvc.perform(get("/orders")
+                .header("version", "1.0.0")
+                .queryParam("page", "0")
+                .queryParam("size", "1"));
+
+        // then: the collection exposes stable pagination metadata
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].id", is(placedOrder.getId().toString())))
+                .andExpect(jsonPath("$.content[0].created_at").isNotEmpty())
+                .andExpect(jsonPath("$.page", is(0)))
+                .andExpect(jsonPath("$.size", is(1)))
+                .andExpect(jsonPath("$.total_elements", greaterThanOrEqualTo(1)))
+                .andExpect(jsonPath("$.total_pages", greaterThanOrEqualTo(1)));
+    }
+
+    @Test
+    @WithMockUser(username = "merchant", roles = "MERCHANT")
+    @DisplayName("Should apply lifecycle and period filters when browsing orders")
+    void shouldApplyLifecycleAndPeriodFiltersWhenBrowsingOrders() throws Exception {
+        // given: at least one placed order exists
+        orderPlacedProvider.placeOrder();
+
+        // when: the merchant filters orders by their lifecycle and a past lower bound
+        var response = mockMvc.perform(get("/orders")
+                .queryParam("status", "PLACED")
+                .queryParam("created_from", Instant.parse("2000-01-01T00:00:00Z").toString())
+                .queryParam("size", "100"));
+
+        // then: every returned order satisfies the requested lifecycle
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(greaterThanOrEqualTo(1))))
+                .andExpect(jsonPath("$.content[*].status", everyItem(is("PLACED"))));
+    }
+
+    @Test
+    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @DisplayName("Should reject an inverted period when browsing orders")
+    void shouldRejectAnInvertedPeriodWhenBrowsingOrders() throws Exception {
+        // given: a period whose start is later than its end
+        var createdFrom = "2026-07-23T00:00:00Z";
+        var createdTo = "2026-07-22T00:00:00Z";
+
+        // when: the customer tries to browse orders in that period
+        var response = mockMvc.perform(get("/orders")
+                .queryParam("created_from", createdFrom)
+                .queryParam("created_to", createdTo));
+
+        // then: the invalid business query is rejected explicitly
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title", is("Invalid Order Listing Period")));
+    }
+}


### PR DESCRIPTION
## Summary

- add a read-only, paginated `GET /orders` endpoint
- support status and ISO-8601 creation-period filters
- remove fabricated order-event fallbacks and return truthful empty/404 responses
- document the expanded order-management surface and architectural decisions

## API behavior

- `page` defaults to `0`
- `size` defaults to `20` and is limited to `100`
- results are ordered by newest creation time and order id
- inverted creation periods return `400 Bad Request`
- missing specific order events return `404 Not Found`

## Verification

- `./gradlew --no-daemon testClasses`
- `./gradlew --no-daemon cleanTest test --tests "*OrderListingControllerTest" --tests "*EventsControllerTest" --tests "com.ead.payments.architecture.*"`
- `git diff --check`

The focused integration suite passed against the local PostgreSQL and Kafka infrastructure.